### PR TITLE
frontend: season-only drivers/constructors, driver images, landing/da…

### DIFF
--- a/frontEnd/f1-fantasy/src/api/constructors.ts
+++ b/frontEnd/f1-fantasy/src/api/constructors.ts
@@ -3,7 +3,7 @@ import type { ConstructorApi } from "./types";
 import type { Constructor } from "../types/constructor";
 import { MOCK_CONSTRUCTORS } from "../data/mockConstructors";
 
-const CURRENT_SEASON = "2025";
+const CURRENT_SEASON = "2026";
 
 /** Map backend API shape to app Constructor (exported for tests). */
 export function mapConstructorApiToConstructor(api: ConstructorApi): Constructor {
@@ -14,15 +14,13 @@ export function mapConstructorApiToConstructor(api: ConstructorApi): Constructor
 }
 
 /**
- * Fetch constructors from backend. Returns null if API is not configured or request fails (caller should use mock).
+ * Fetch constructors for the current season from backend.
+ * Returns null if API is not configured or request fails (caller should use mock).
+ * Only uses season endpoint so we only display current-season constructors.
  */
 export async function fetchConstructorsFromApi(): Promise<Constructor[] | null> {
   if (!getApiBaseUrl()) return null;
   try {
-    const cached = await apiGet<ConstructorApi[]>("/api/constructor/cached");
-    if (Array.isArray(cached) && cached.length > 0) {
-      return cached.map(mapConstructorApiToConstructor);
-    }
     const bySeason = await apiGet<ConstructorApi[]>(`/api/constructor/season/${CURRENT_SEASON}`);
     if (Array.isArray(bySeason) && bySeason.length > 0) {
       return bySeason.map(mapConstructorApiToConstructor);

--- a/frontEnd/f1-fantasy/src/api/drivers.test.ts
+++ b/frontEnd/f1-fantasy/src/api/drivers.test.ts
@@ -6,6 +6,11 @@ import {
 } from "./drivers";
 import type { DriverApi } from "./types";
 
+vi.mock("./client", () => ({
+  getApiBaseUrl: vi.fn(() => "https://api.example.com"),
+  apiGet: vi.fn(),
+}));
+
 describe("mapDriverApiToDriver", () => {
   it("maps API driver to app Driver with lowercase id", () => {
     const api: DriverApi = {
@@ -22,7 +27,22 @@ describe("mapDriverApiToDriver", () => {
       id: "ver",
       name: "Max Verstappen",
       teamId: undefined,
+      wikipediaUrl: undefined,
     });
+  });
+
+  it("maps API driver wikipedia url to wikipediaUrl", () => {
+    const api: DriverApi = {
+      driverId: "VER",
+      permanentNumber: "1",
+      code: "VER",
+      url: "https://en.wikipedia.org/wiki/Max_Verstappen",
+      givenName: "Max",
+      familyName: "Verstappen",
+      dateOfBirth: "1997-09-30",
+      nationality: "Dutch",
+    };
+    expect(mapDriverApiToDriver(api).wikipediaUrl).toBe("https://en.wikipedia.org/wiki/Max_Verstappen");
   });
 
   it("trims name and handles single name", () => {
@@ -59,12 +79,9 @@ describe("getMockDrivers", () => {
 
 describe("fetchDriversFromApi", () => {
   it("returns Promise that resolves to Driver[] or null", async () => {
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
-      ok: false,
-      status: 500,
-    } as Response);
+    const { apiGet } = await import("./client");
+    vi.mocked(apiGet).mockRejectedValueOnce(new Error("API 500"));
     const result = await fetchDriversFromApi();
-    fetchSpy.mockRestore();
     expect(result === null || Array.isArray(result)).toBe(true);
     if (result !== null) {
       result.forEach((d) => {
@@ -72,5 +89,37 @@ describe("fetchDriversFromApi", () => {
         expect(d).toHaveProperty("name");
       });
     }
+  });
+
+  it("returns all drivers from season API (no permanentNumber filter)", async () => {
+    const { apiGet } = await import("./client");
+    const apiDrivers: DriverApi[] = [
+      {
+        driverId: "ver",
+        permanentNumber: "1",
+        code: "VER",
+        url: "",
+        givenName: "Max",
+        familyName: "Verstappen",
+        dateOfBirth: "1997-09-30",
+        nationality: "Dutch",
+      },
+      {
+        driverId: "reserve_1",
+        permanentNumber: "",
+        code: "RES",
+        url: "",
+        givenName: "Reserve",
+        familyName: "Driver",
+        dateOfBirth: "2000-01-01",
+        nationality: "British",
+      },
+    ];
+    vi.mocked(apiGet).mockResolvedValueOnce(apiDrivers);
+    const result = await fetchDriversFromApi();
+    expect(result).not.toBeNull();
+    expect(result!.length).toBe(2);
+    expect(result![0].id).toBe("ver");
+    expect(result![1].id).toBe("reserve_1");
   });
 });

--- a/frontEnd/f1-fantasy/src/api/drivers.ts
+++ b/frontEnd/f1-fantasy/src/api/drivers.ts
@@ -3,7 +3,7 @@ import type { DriverApi } from "./types";
 import type { Driver } from "../types/driver";
 import { MOCK_DRIVERS } from "../data/mockDrivers";
 
-const CURRENT_SEASON = "2025";
+const CURRENT_SEASON = "2026";
 
 /** Map backend API shape to app Driver (exported for tests). */
 export function mapDriverApiToDriver(api: DriverApi): Driver {
@@ -11,20 +11,18 @@ export function mapDriverApiToDriver(api: DriverApi): Driver {
     id: api.driverId.toLowerCase(),
     name: `${api.givenName} ${api.familyName}`.trim(),
     teamId: undefined,
+    wikipediaUrl: api.url?.trim() || undefined,
   };
 }
 
 /**
- * Fetch drivers from backend. Returns null if API is not configured or request fails (caller should use mock).
+ * Fetch drivers for the current season from the API.
+ * Returns null if API is not configured or request fails (caller should use mock).
+ * Season endpoint determines who is returned; no additional filtering.
  */
 export async function fetchDriversFromApi(): Promise<Driver[] | null> {
   if (!getApiBaseUrl()) return null;
   try {
-    const cached = await apiGet<DriverApi[] | { drivers?: DriverApi[] }>("/api/driver/cached");
-    const list = Array.isArray(cached) ? cached : cached?.drivers;
-    if (Array.isArray(list) && list.length > 0) {
-      return list.map(mapDriverApiToDriver);
-    }
     const bySeason = await apiGet<DriverApi[]>(`/api/driver/season/${CURRENT_SEASON}`);
     if (Array.isArray(bySeason) && bySeason.length > 0) {
       return bySeason.map(mapDriverApiToDriver);

--- a/frontEnd/f1-fantasy/src/api/types.ts
+++ b/frontEnd/f1-fantasy/src/api/types.ts
@@ -5,7 +5,8 @@
 
 export interface DriverApi {
   driverId: string;
-  permanentNumber: string;
+  /** Race drivers have a number; reserves may omit or have empty. */
+  permanentNumber?: string;
   code: string;
   url: string;
   givenName: string;

--- a/frontEnd/f1-fantasy/src/api/wikipediaImage.test.ts
+++ b/frontEnd/f1-fantasy/src/api/wikipediaImage.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getWikipediaImageUrl } from "./wikipediaImage";
+
+describe("getWikipediaImageUrl", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        if (url.includes("Max_Verstappen")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                thumbnail: { source: "https://upload.wikimedia.org/example.jpg" },
+              }),
+          } as Response);
+        }
+        return Promise.resolve({ ok: false } as Response);
+      })
+    );
+  });
+
+  it("returns null for non-Wikipedia URL", async () => {
+    const result = await getWikipediaImageUrl("https://example.com/foo");
+    expect(result).toBeNull();
+  });
+
+  it("returns thumbnail URL for valid Wikipedia page URL", async () => {
+    const result = await getWikipediaImageUrl(
+      "https://en.wikipedia.org/wiki/Max_Verstappen"
+    );
+    expect(result).toBe("https://upload.wikimedia.org/example.jpg");
+  });
+
+  it("returns null when API response has no thumbnail", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({}),
+    } as Response);
+    const result = await getWikipediaImageUrl(
+      "https://en.wikipedia.org/wiki/Some_Page"
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/frontEnd/f1-fantasy/src/api/wikipediaImage.ts
+++ b/frontEnd/f1-fantasy/src/api/wikipediaImage.ts
@@ -1,0 +1,50 @@
+/**
+ * Resolve a Wikipedia page URL to its main image URL via Wikipedia REST API.
+ * Cached per session to avoid repeated requests.
+ */
+
+const CACHE = new Map<string, string | null>();
+
+function titleFromWikipediaUrl(url: string): string | null {
+  try {
+    const u = new URL(url);
+    if (!/^https?:\/\/(?:en\.)?wikipedia\.org\/wiki\//i.test(url)) return null;
+    const segment = u.pathname.split("/wiki/")[1];
+    return segment ? decodeURIComponent(segment.replace(/_/g, " ")) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch the main image URL for a Wikipedia page. Returns null if not a Wikipedia URL or no image.
+ */
+export async function getWikipediaImageUrl(wikipediaUrl: string): Promise<string | null> {
+  const cached = CACHE.get(wikipediaUrl);
+  if (cached !== undefined) return cached;
+
+  const title = titleFromWikipediaUrl(wikipediaUrl);
+  if (!title) {
+    CACHE.set(wikipediaUrl, null);
+    return null;
+  }
+
+  try {
+    const encoded = encodeURIComponent(title.replace(/ /g, "_"));
+    const res = await fetch(
+      `https://en.wikipedia.org/api/rest_v1/page/summary/${encoded}`,
+      { headers: { "Accept": "application/json" } }
+    );
+    if (!res.ok) {
+      CACHE.set(wikipediaUrl, null);
+      return null;
+    }
+    const data = await res.json();
+    const imageUrl = data.thumbnail?.source ?? null;
+    CACHE.set(wikipediaUrl, imageUrl);
+    return imageUrl;
+  } catch {
+    CACHE.set(wikipediaUrl, null);
+    return null;
+  }
+}

--- a/frontEnd/f1-fantasy/src/index.css
+++ b/frontEnd/f1-fantasy/src/index.css
@@ -28,8 +28,86 @@ html, body {
 }
 
 /* Clerk sign-in: readable social icons (e.g. GitHub), "Don't have an account?", "Secured by" */
+/* Sign-in card: dark background, 1rem padding, white border */
+.sign-in-card.ant-card {
+  border: 1px solid #ffffff !important;
+  box-shadow: none !important;
+  background: #1a1a1a !important;
+}
+.sign-in-card.ant-card .ant-card-body {
+  padding: 1rem !important;
+  margin: 0 !important;
+  background: #1a1a1a !important;
+  width: 100% !important;
+  box-sizing: border-box !important;
+}
+.sign-in-card .sign-in-fill-card {
+  margin: 0 !important;
+  padding: 0 !important;
+  width: 100% !important;
+}
+.sign-in-fill-card .clerk-f1-theme {
+  background-color: #1a1a1a !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  min-height: 100%;
+  width: 100% !important;
+  box-sizing: border-box !important;
+}
 .clerk-f1-theme {
   --clerk-color-muted-foreground: #c4c4c4;
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+}
+/* Clerk sign-in: responsive card so content is never cut off on small screens */
+.clerk-f1-theme .cl-card,
+.clerk-f1-theme [class*="cl-cardBox"] {
+  max-width: 100% !important;
+  min-width: 0 !important;
+  width: 100% !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+.sign-in-fill-card .clerk-f1-theme .cl-card,
+.sign-in-fill-card .clerk-f1-theme [class*="cl-cardBox"] {
+  padding: 0 !important;
+  margin: 0 !important;
+  background: transparent !important;
+}
+.clerk-f1-theme .cl-formButtonRoot,
+.clerk-f1-theme .cl-socialButtonsBlock,
+.clerk-f1-theme form {
+  max-width: 100%;
+  min-width: 0;
+  width: 100%;
+}
+/* Clerk sign-in: content fills the card (no wide border with narrow content) */
+.clerk-f1-theme .cl-card,
+.clerk-f1-theme [class*="cl-cardBox"],
+.clerk-f1-theme [class*="cl-rootBox"] {
+  width: 100% !important;
+  max-width: 100% !important;
+}
+.clerk-f1-theme form,
+.clerk-f1-theme [class*="cl-form"] {
+  width: 100% !important;
+}
+.clerk-f1-theme input,
+.clerk-f1-theme .cl-input,
+.clerk-f1-theme [class*="cl-input"] {
+  width: 100% !important;
+  box-sizing: border-box !important;
+}
+.clerk-f1-theme button[type="submit"],
+.clerk-f1-theme .cl-formButtonPrimary,
+.clerk-f1-theme [class*="cl-formButtonPrimary"] {
+  width: 100% !important;
+}
+.clerk-f1-theme .cl-socialButtonsBlock button,
+.clerk-f1-theme .cl-formButtonRoot button,
+.clerk-f1-theme [class*="cl-socialButtons"] button {
+  width: 100% !important;
 }
 /* Clerk GitHub button: was color(srgb 0.27 0.27 0.27 / 0.62) – invisible on dark. Force white. */
 .cl-socialButtonsIconButton__github,
@@ -115,4 +193,17 @@ body > div[class*="cl-"] div {
 }
 body > div[class*="cl-"] a:hover {
   color: #e10600 !important;
+}
+
+/* Driver select dropdown: highlight must contrast with text (dark bg, light text) so option is readable */
+.f1-driver-select-dropdown.ant-select-dropdown .ant-select-item-option {
+  color: #e5e5e5;
+}
+.f1-driver-select-dropdown.ant-select-dropdown .ant-select-item-option-active,
+.f1-driver-select-dropdown.ant-select-dropdown .ant-select-item-option-selected {
+  background-color: #404040 !important;
+  color: #ffffff !important;
+}
+.f1-driver-select-dropdown.ant-select-dropdown .ant-select-item-option-selected .ant-select-item-option-state {
+  color: #e10600;
 }

--- a/frontEnd/f1-fantasy/src/molecules/DriverAvatar.tsx
+++ b/frontEnd/f1-fantasy/src/molecules/DriverAvatar.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from "react";
+import { getWikipediaImageUrl } from "../api/wikipediaImage";
 import { useDrivers } from "../state/useDriversAndConstructors";
 
 /** Stable background color from driver id (no external image needed). */
@@ -33,12 +35,28 @@ export function DriverAvatar({ driverId, size = 48, showName = true, className =
   const initials = getInitials(name);
   const bg = avatarColor(driverId);
 
+  const [resolvedImageUrl, setResolvedImageUrl] = useState<string | null>(null);
+  const imageUrl = driver?.imageUrl ?? resolvedImageUrl;
+
+  useEffect(() => {
+    if (!driver?.wikipediaUrl || driver.imageUrl) {
+      setResolvedImageUrl(null);
+      return;
+    }
+    setResolvedImageUrl(null);
+    let cancelled = false;
+    getWikipediaImageUrl(driver.wikipediaUrl).then((url) => {
+      if (!cancelled) setResolvedImageUrl(url);
+    });
+    return () => { cancelled = true; };
+  }, [driver?.wikipediaUrl, driver?.imageUrl]);
+
   return (
     <div className={`flex min-w-0 items-center gap-2 ${className}`}>
       <div
         role="img"
         aria-label={name}
-        className="shrink-0 rounded-full border border-f1-gray flex items-center justify-center font-semibold text-white select-none"
+        className="shrink-0 rounded-full border border-f1-gray flex items-center justify-center font-semibold text-white select-none overflow-hidden"
         style={{
           width: size,
           height: size,
@@ -46,7 +64,17 @@ export function DriverAvatar({ driverId, size = 48, showName = true, className =
           fontSize: Math.max(10, Math.floor(size * 0.4)),
         }}
       >
-        {initials}
+        {imageUrl ? (
+          <img
+            src={imageUrl}
+            alt=""
+            className="w-full h-full object-cover"
+            width={size}
+            height={size}
+          />
+        ) : (
+          initials
+        )}
       </div>
       {showName && <span className="min-w-0 truncate text-sm text-f1-silver">{name}</span>}
     </div>

--- a/frontEnd/f1-fantasy/src/molecules/EmptyState.tsx
+++ b/frontEnd/f1-fantasy/src/molecules/EmptyState.tsx
@@ -8,6 +8,8 @@ type EmptyStateProps = {
   buttonLabel: string;
   buttonIcon?: ReactNode;
   onAction: () => void;
+  /** Optional illustration (e.g. F1-themed SVG) shown above the icon */
+  illustration?: ReactNode;
 };
 
 export function EmptyState({
@@ -16,9 +18,11 @@ export function EmptyState({
   buttonLabel,
   buttonIcon,
   onAction,
+  illustration,
 }: EmptyStateProps) {
   return (
     <F1Card className="min-w-0 py-8 text-center sm:py-12">
+      {illustration && <div className="mb-4 flex justify-center">{illustration}</div>}
       <TeamOutlined className="text-5xl text-f1-gray mb-4" />
       <F1Title level={4}>{title}</F1Title>
       <F1Text muted className="block mb-6">

--- a/frontEnd/f1-fantasy/src/molecules/SignInModule.tsx
+++ b/frontEnd/f1-fantasy/src/molecules/SignInModule.tsx
@@ -42,8 +42,11 @@ export function SignInModule() {
   }, []);
 
   return (
-    <F1Card className="w-full max-w-md flex-1 overflow-hidden" styles={{ body: { padding: 0 } }}>
-      <div className="min-w-0 overflow-x-hidden">
+    <F1Card
+      className="sign-in-card w-full min-w-0 max-w-md flex-1 shrink self-center md:self-auto"
+      styles={{ body: { padding: "1rem", overflow: "visible", background: "#1a1a1a" } }}
+    >
+      <div className="min-w-0 w-full sign-in-fill-card">
         <SignIn appearance={clerkF1Appearance} />
       </div>
     </F1Card>

--- a/frontEnd/f1-fantasy/src/molecules/TwoDriverPicker.tsx
+++ b/frontEnd/f1-fantasy/src/molecules/TwoDriverPicker.tsx
@@ -5,6 +5,10 @@ import { useDrivers } from "../state/useDriversAndConstructors";
 
 export type TwoDriverValue = { driverId1: string; driverId2: string };
 
+const selectClass =
+  "w-full [&_.ant-select-selector]:bg-f1-gray [&_.ant-select-selector]:border-f1-gray [&_.ant-select-selection-item]:text-f1-silver f1-driver-select";
+const dropdownClass = "f1-driver-select-dropdown";
+
 type TwoDriverPickerProps = {
   value: TwoDriverValue | undefined;
   onSave: (prediction: TwoDriverValue) => void;
@@ -19,7 +23,7 @@ export function TwoDriverPicker({ value, onSave, labels = ["Driver 1", "Driver 2
   const [driverId2, setDriverId2] = useState(value?.driverId2 ?? "");
 
   const handleSave = () => {
-    if (driverId1 && driverId2) onSave({ driverId1, driverId2 });
+    if (driverId1 && driverId2 && driverId1 !== driverId2) onSave({ driverId1, driverId2 });
   };
 
   const isValid = Boolean(driverId1 && driverId2 && driverId1 !== driverId2);
@@ -34,8 +38,14 @@ export function TwoDriverPicker({ value, onSave, labels = ["Driver 1", "Driver 2
             value={driverId1 || undefined}
             onChange={setDriverId1}
             options={driverOptions}
-            className="w-full [&_.ant-select-selector]:bg-f1-gray [&_.ant-select-selector]:border-f1-gray [&_.ant-select-selection-item]:text-f1-silver"
+            className={selectClass}
+            popupClassName={dropdownClass}
             allowClear
+            showSearch
+            filterOption={(input, option) =>
+              (option?.label ?? "").toString().toLowerCase().includes(input.toLowerCase())
+            }
+            optionFilterProp="label"
           />
         </div>
         <div className="min-w-48">
@@ -48,14 +58,22 @@ export function TwoDriverPicker({ value, onSave, labels = ["Driver 1", "Driver 2
               ...opt,
               disabled: opt.value === driverId1,
             }))}
-            className="w-full [&_.ant-select-selector]:bg-f1-gray [&_.ant-select-selector]:border-f1-gray [&_.ant-select-selection-item]:text-f1-silver"
+            className={selectClass}
+            popupClassName={dropdownClass}
             allowClear
+            showSearch
+            filterOption={(input, option) =>
+              (option?.label ?? "").toString().toLowerCase().includes(input.toLowerCase())
+            }
+            optionFilterProp="label"
           />
         </div>
       </div>
-      <F1Button type="primary" onClick={handleSave} disabled={!isValid}>
-        Save prediction
-      </F1Button>
+      {isValid && (
+        <F1Button type="primary" onClick={handleSave}>
+          Save prediction
+        </F1Button>
+      )}
       {driverId1 && driverId2 && driverId1 === driverId2 && (
         <p className="text-xs text-amber-200">Pick two different drivers.</p>
       )}

--- a/frontEnd/f1-fantasy/src/molecules/ZeroPointersEditor.tsx
+++ b/frontEnd/f1-fantasy/src/molecules/ZeroPointersEditor.tsx
@@ -32,8 +32,14 @@ export function ZeroPointersEditor({ value, onSave }: ZeroPointersEditorProps) {
           value={driverIds}
           onChange={(ids) => setDriverIds(ids.slice(0, maxDriverCount))}
           options={driverOptions}
-          className="w-full [&_.ant-select-selector]:bg-f1-gray [&_.ant-select-selector]:border-f1-gray [&_.ant-select-selection-item]:text-f1-silver"
+          className="w-full [&_.ant-select-selector]:bg-f1-gray [&_.ant-select-selector]:border-f1-gray [&_.ant-select-selection-item]:text-f1-silver f1-driver-select"
+          popupClassName="f1-driver-select-dropdown"
           maxTagCount="responsive"
+          showSearch
+          filterOption={(input, option) =>
+            (option?.label ?? "").toString().toLowerCase().includes(input.toLowerCase())
+          }
+          optionFilterProp="label"
         />
       </div>
       <F1Button type="primary" onClick={handleSave}>

--- a/frontEnd/f1-fantasy/src/organisms/DashboardContent.tsx
+++ b/frontEnd/f1-fantasy/src/organisms/DashboardContent.tsx
@@ -4,6 +4,41 @@ import { EmptyState } from "../molecules";
 import { GroupList } from "./GroupList";
 import type { Group } from "../types/group";
 
+/** Real F1 photo for dashboard banner (Wikimedia Commons, CC). Mercedes W09. */
+const DASHBOARD_BANNER_IMAGE_URL =
+  "https://upload.wikimedia.org/wikipedia/commons/3/3f/Lewis_Hamilton%27s_2018_Mercedes_AMG_W09_Hybrid_Formula_1_Car_%2852339096904%29.jpg";
+
+/** Banner: F1 photo as background with How it works / Rules text overlaid. */
+function InfoBanner() {
+  return (
+    <section className="relative min-h-[220px] sm:min-h-[260px] rounded-lg border border-f1-gray overflow-hidden bg-f1-black">
+      <img
+        src={DASHBOARD_BANNER_IMAGE_URL}
+        alt=""
+        className="absolute inset-0 h-full w-full object-cover"
+        loading="lazy"
+      />
+      <div className="absolute inset-0 bg-black/60" aria-hidden />
+      <div className="relative z-10 space-y-3 p-4 sm:p-5 md:p-6">
+        <F1Title level={5} className="!mb-1">How it works</F1Title>
+        <p className="text-sm text-f1-silver max-w-2xl">
+          Create or join a group with an invite code. Make predictions across seven categories (drivers, constructors, draft, destructors, Mr Saturday, zero pointers, wildcard). Compare your picks with friends and see who scores the most when the season unfolds.
+        </p>
+        <F1Title level={5} className="!mb-1 !mt-2">Rules</F1Title>
+        <p className="text-sm text-f1-silver max-w-2xl">
+          Points are awarded per category based on real-world results. Check each category for scoring details. The group standings show combined scores—highest total wins.
+        </p>
+        <p className="text-sm text-f1-silver max-w-2xl">
+          <strong className="text-f1-silver">Locking predictions.</strong> When you’re happy with your picks, lock your predictions. Once locked, you can’t edit them unless you unlock again before the season starts.
+        </p>
+        <p className="text-sm text-f1-silver max-w-2xl">
+          <strong className="text-f1-silver">Season start.</strong> When the season starts (e.g. first race), all predictions are automatically locked and can no longer be changed.
+        </p>
+      </div>
+    </section>
+  );
+}
+
 type DashboardContentProps = {
   groups: Group[];
   onCreateGroup: () => void;
@@ -13,16 +48,7 @@ type DashboardContentProps = {
 export function DashboardContent({ groups, onCreateGroup, onJoinGroup }: DashboardContentProps) {
   return (
     <div className="space-y-6 sm:space-y-8">
-      <section className="rounded-lg border border-f1-gray bg-f1-carbon/50 space-y-3 p-3 sm:p-4">
-        <F1Title level={5} className="!mb-1">How it works</F1Title>
-        <p className="text-sm text-f1-silver">
-          Create or join a group with an invite code. Make predictions across seven categories (drivers, constructors, draft, destructors, Mr Saturday, zero pointers, wildcard). Compare your picks with friends and see who scores the most when the season unfolds.
-        </p>
-        <F1Title level={5} className="!mb-1 !mt-2">Rules</F1Title>
-        <p className="text-sm text-f1-silver">
-          Points are awarded per category based on real-world results. Check each category for scoring details. The group standings show combined scores—highest total wins.
-        </p>
-      </section>
+      <InfoBanner />
 
       <div className="flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
         <F1Title level={2} className="!text-xl sm:!text-2xl">Your groups</F1Title>

--- a/frontEnd/f1-fantasy/src/organisms/LandingHeroWithSignIn.tsx
+++ b/frontEnd/f1-fantasy/src/organisms/LandingHeroWithSignIn.tsx
@@ -1,54 +1,38 @@
 import { LandingCopy, SignInModule } from "../molecules";
 
-/** Inline hero graphic so it works without external image requests (no CORS/blocking). */
-function HeroGraphic() {
+/** Real F1 car photo (Wikimedia Commons, CC). Williams FW38 – replace with any F1 image URL if needed. */
+const HERO_IMAGE_URL =
+  "https://upload.wikimedia.org/wikipedia/commons/c/c5/2016_Williams_FW38_Formula_1_Car_%2853436323345%29.jpg";
+
+/** Hero background: actual F1 image with dark overlay for text readability. */
+function HeroBannerBackground() {
   return (
-    <div
-      className="h-40 w-full max-w-md rounded-lg border border-f1-gray shadow-lg overflow-hidden sm:h-48 md:h-56"
-      aria-hidden
-    >
-      <svg
-        viewBox="0 0 400 240"
-        className="h-full w-full object-cover"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <defs>
-          <linearGradient id="heroBg" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" stopColor="#0f172a" />
-            <stop offset="50%" stopColor="#1e293b" />
-            <stop offset="100%" stopColor="#0f172a" />
-          </linearGradient>
-          <linearGradient id="heroAccent" x1="0%" y1="100%" x2="100%" y2="0%">
-            <stop offset="0%" stopColor="#dc2626" stopOpacity="0.9" />
-            <stop offset="100%" stopColor="#b91c1c" stopOpacity="0.6" />
-          </linearGradient>
-        </defs>
-        <rect width="400" height="240" fill="url(#heroBg)" />
-        <ellipse cx="200" cy="140" rx="160" ry="50" fill="url(#heroAccent)" opacity="0.25" />
-        <path
-          d="M40 180 Q120 100 200 120 T360 100"
-          stroke="#dc2626"
-          strokeWidth="3"
-          strokeOpacity="0.6"
-          fill="none"
-        />
-        <circle cx="80" cy="175" r="8" fill="#dc2626" opacity="0.9" />
-        <circle cx="200" cy="115" r="8" fill="#dc2626" opacity="0.9" />
-        <circle cx="320" cy="95" r="8" fill="#dc2626" opacity="0.9" />
-      </svg>
+    <div className="absolute inset-0 overflow-hidden bg-f1-black" aria-hidden>
+      <img
+        src={HERO_IMAGE_URL}
+        alt=""
+        className="absolute inset-0 h-full w-full object-cover"
+        loading="eager"
+        fetchPriority="high"
+      />
+      {/* Dark overlay so text and sign-in card stay readable */}
+      <div className="absolute inset-0 bg-black/55" />
     </div>
   );
 }
 
 export function LandingHeroWithSignIn() {
   return (
-    <div className="flex min-h-[70vh] flex-col items-center justify-center gap-6 py-6 sm:min-h-[80vh] sm:gap-10 md:flex-row md:gap-12">
-      <LandingCopy />
-      <div className="flex w-full max-w-full flex-col items-center gap-4 sm:gap-6 md:w-auto">
-        <HeroGraphic />
-        <SignInModule />
+    <section className="relative flex min-h-[70vh] flex-col items-center justify-center py-10 sm:min-h-[80vh] sm:py-14">
+      <HeroBannerBackground />
+      <div className="relative z-10 flex w-full max-w-5xl flex-col items-stretch gap-8 px-4 sm:gap-10 md:flex-row md:items-center md:justify-between md:gap-12 lg:px-8">
+        <div className="w-full min-w-0 md:max-w-md">
+          <LandingCopy />
+        </div>
+        <div className="w-full min-w-0 flex justify-center md:justify-end">
+          <SignInModule />
+        </div>
       </div>
-    </div>
+    </section>
   );
 }

--- a/frontEnd/f1-fantasy/src/types/driver.ts
+++ b/frontEnd/f1-fantasy/src/types/driver.ts
@@ -4,4 +4,6 @@ export interface Driver {
   teamId?: string;
   /** Optional headshot/avatar URL for display in predictions */
   imageUrl?: string;
+  /** Wikipedia page URL from API; used to fetch main image via Wikipedia REST API */
+  wikipediaUrl?: string;
 }


### PR DESCRIPTION
- API: fetch drivers/constructors by season (2026) only; remove permanentNumber filter
- Driver avatars: Wikipedia image from API url with fallback to initials
- Landing: real F1 hero image (Wikimedia), responsive sign-in layout
- Dashboard: info banner with F1 photo + overlaid text; remove empty-state image
- Sign-in card: dark background, 1rem padding, white border; Clerk content full-width
- Driver pickers: searchable (showSearch/filterOption), readable dropdown highlight
- TwoDriverPicker: show Save button only when both drivers selected and valid
- Rules: add locking and season-start auto-lock
- DATA_STRUCTURES_FOR_BACKEND.md for backend/DB