### PR TITLE
feat: add Clerk session token to API request headers

### DIFF
--- a/frontEnd/f1-fantasy/src/App.tsx
+++ b/frontEnd/f1-fantasy/src/App.tsx
@@ -1,5 +1,8 @@
+import { useEffect } from "react";
+import { useAuth } from "@clerk/clerk-react";
 import { ConfigProvider } from "antd";
 import { RecoilRoot } from "recoil";
+import { setAuthTokenGetter } from "./api/client";
 import Index from "./pages/Index.tsx";
 
 const f1Theme = {
@@ -13,13 +16,26 @@ const f1Theme = {
     },
 };
 
+/** Registers Clerk session token with the API client so requests send Authorization: Bearer <token>. */
+function ApiAuthSetup() {
+    const { getToken } = useAuth();
+    useEffect(() => {
+        setAuthTokenGetter(() => getToken());
+        return () => setAuthTokenGetter(null);
+    }, [getToken]);
+    return null;
+}
+
 function App() {
     return (
-        <ConfigProvider theme={f1Theme}>
-            <RecoilRoot>
-                <Index />
-            </RecoilRoot>
-        </ConfigProvider>
+        <>
+            <ApiAuthSetup />
+            <ConfigProvider theme={f1Theme}>
+                <RecoilRoot>
+                    <Index />
+                </RecoilRoot>
+            </ConfigProvider>
+        </>
     );
 }
 export default App;

--- a/frontEnd/f1-fantasy/src/api/client.ts
+++ b/frontEnd/f1-fantasy/src/api/client.ts
@@ -1,15 +1,32 @@
 const BASE_URL = import.meta.env.VITE_API_BASE_URL as string | undefined;
 
+/** Optional: set from app so API requests include Clerk session token. */
+let authTokenGetter: (() => Promise<string | null>) | null = null;
+
+export function setAuthTokenGetter(getter: (() => Promise<string | null>) | null): void {
+  authTokenGetter = getter;
+}
+
 export function getApiBaseUrl(): string | undefined {
   if (!BASE_URL || BASE_URL.trim() === "") return undefined;
   return BASE_URL.replace(/\/$/, "");
+}
+
+async function getAuthHeaders(): Promise<Record<string, string>> {
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (authTokenGetter) {
+    const token = await authTokenGetter();
+    if (token) headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
 }
 
 export async function apiGet<T>(path: string): Promise<T> {
   const base = getApiBaseUrl();
   if (!base) throw new Error("VITE_API_BASE_URL is not set");
   const url = path.startsWith("http") ? path : `${base}${path.startsWith("/") ? path : `/${path}`}`;
-  const res = await fetch(url, { method: "GET", headers: { Accept: "application/json" } });
+  const headers = await getAuthHeaders();
+  const res = await fetch(url, { method: "GET", headers });
   if (!res.ok) throw new Error(`API ${res.status}: ${res.statusText}`);
   return res.json() as Promise<T>;
 }


### PR DESCRIPTION
- API client accepts auth token getter; sends Authorization: Bearer <token>
- ApiAuthSetup in App registers Clerk getToken() so requests are authenticated
- Backend can verify user is logged in via JWT