### PR TITLE
feat: Add Clerk JWT authentication to all API endpoints

### DIFF
--- a/backend/F1Fantasy/Controllers/CircuitController.cs
+++ b/backend/F1Fantasy/Controllers/CircuitController.cs
@@ -1,9 +1,11 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using F1Fantasy.Models;
 using F1Fantasy.Services;
 
 namespace F1Fantasy.Controllers;
 
+[Authorize]
 [ApiController]
 [Route("api/[controller]")]
 public class CircuitController : ControllerBase

--- a/backend/F1Fantasy/Controllers/ConstructorController.cs
+++ b/backend/F1Fantasy/Controllers/ConstructorController.cs
@@ -1,9 +1,11 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using F1Fantasy.Models;
 using F1Fantasy.Services;
 
 namespace F1Fantasy.Controllers;
 
+[Authorize]
 [ApiController]
 [Route("api/[controller]")]
 public class ConstructorController : ControllerBase

--- a/backend/F1Fantasy/Controllers/ConstructorStandingController.cs
+++ b/backend/F1Fantasy/Controllers/ConstructorStandingController.cs
@@ -1,9 +1,11 @@
 using F1Fantasy.Models;
 using F1Fantasy.Services;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace F1Fantasy.Controllers;
 
+[Authorize]
 [ApiController]
 [Route("api/[controller]")]
 public class ConstructorStandingController : ControllerBase

--- a/backend/F1Fantasy/Controllers/DriverController.cs
+++ b/backend/F1Fantasy/Controllers/DriverController.cs
@@ -1,9 +1,11 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using F1Fantasy.Models;
 using F1Fantasy.Services;
 
 namespace F1Fantasy.Controllers;
 
+[Authorize]
 [ApiController]
 [Route("api/[controller]")]
 public class DriverController : ControllerBase

--- a/backend/F1Fantasy/Controllers/DriverStandingController.cs
+++ b/backend/F1Fantasy/Controllers/DriverStandingController.cs
@@ -1,9 +1,11 @@
 using F1Fantasy.Models;
 using F1Fantasy.Services;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace F1Fantasy.Controllers;
 
+[Authorize]
 [ApiController]
 [Route("api/[controller]")]
 public class DriverStandingController : ControllerBase

--- a/backend/F1Fantasy/Controllers/LapTimingController.cs
+++ b/backend/F1Fantasy/Controllers/LapTimingController.cs
@@ -1,9 +1,11 @@
 using F1Fantasy.Models;
 using F1Fantasy.Services;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace F1Fantasy.Controllers;
 
+[Authorize]
 [ApiController]
 [Route("api/[controller]")]
 public class LapTimingController : ControllerBase

--- a/backend/F1Fantasy/Controllers/PitStopController.cs
+++ b/backend/F1Fantasy/Controllers/PitStopController.cs
@@ -1,9 +1,11 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using F1Fantasy.Models;
 using F1Fantasy.Services;
 
 namespace F1Fantasy.Controllers;
 
+[Authorize]
 [ApiController]
 [Route("api/[controller]")]
 public class PitStopController : ControllerBase

--- a/backend/F1Fantasy/Controllers/QualifyingController.cs
+++ b/backend/F1Fantasy/Controllers/QualifyingController.cs
@@ -1,9 +1,11 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using F1Fantasy.Models;
 using F1Fantasy.Services;
 
 namespace F1Fantasy.Controllers;
 
+[Authorize]
 [ApiController]
 [Route("api/[controller]")]
 public class QualifyingController : ControllerBase

--- a/backend/F1Fantasy/Controllers/RaceController.cs
+++ b/backend/F1Fantasy/Controllers/RaceController.cs
@@ -1,9 +1,11 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using F1Fantasy.Models;
 using F1Fantasy.Services;
 
 namespace F1Fantasy.Controllers;
 
+[Authorize]
 [ApiController]
 [Route("api/[controller]")]
 public class RaceController : ControllerBase

--- a/backend/F1Fantasy/Controllers/ResultController.cs
+++ b/backend/F1Fantasy/Controllers/ResultController.cs
@@ -1,9 +1,11 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using F1Fantasy.Models;
 using F1Fantasy.Services;
 
 namespace F1Fantasy.Controllers;
 
+[Authorize]
 [ApiController]
 [Route("api/[controller]")]
 public class ResultController : ControllerBase

--- a/backend/F1Fantasy/Controllers/SeasonController.cs
+++ b/backend/F1Fantasy/Controllers/SeasonController.cs
@@ -1,9 +1,11 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using F1Fantasy.Models;
 using F1Fantasy.Services;
 
 namespace F1Fantasy.Controllers;
 
+[Authorize]
 [ApiController]
 [Route("api/[controller]")]
 public class SeasonController : ControllerBase

--- a/backend/F1Fantasy/Controllers/StatusController.cs
+++ b/backend/F1Fantasy/Controllers/StatusController.cs
@@ -1,9 +1,11 @@
 using F1Fantasy.Models;
 using F1Fantasy.Services;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace F1Fantasy.Controllers;
 
+[Authorize]
 [ApiController]
 [Route("api/[controller]")]
 public class StatusController : ControllerBase

--- a/backend/F1Fantasy/F1Fantasy.csproj
+++ b/backend/F1Fantasy/F1Fantasy.csproj
@@ -7,7 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Clerk.BackendAPI" Version="0.15.3" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/backend/F1Fantasy/Program.cs
+++ b/backend/F1Fantasy/Program.cs
@@ -1,7 +1,11 @@
 using DotNetEnv;
 using F1Fantasy.Data;
 using F1Fantasy.Middleware;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using System.Security.Claims;
+using System.Text;
 
 // Load environment variables from .env file in development
 if (Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Development" || 
@@ -82,6 +86,50 @@ builder.Services.AddScoped<F1Fantasy.Services.ConstructorStandingService>();
 builder.Services.AddScoped<F1Fantasy.Repository.StatusRepository>();
 builder.Services.AddScoped<F1Fantasy.Services.StatusService>();
 
+// Configure Clerk JWT Authentication
+var clerkSecretKey = Environment.GetEnvironmentVariable("CLERK_SECRET_KEY");
+if (string.IsNullOrEmpty(clerkSecretKey))
+{
+    throw new InvalidOperationException("CLERK_SECRET_KEY environment variable is not set. Please configure it in .env file.");
+}
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.Authority = "https://clerk.com";
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidateAudience = false, // Clerk doesn't use audience validation by default
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            ValidIssuer = "https://clerk.com",
+            ClockSkew = TimeSpan.FromMinutes(5)
+        };
+        
+        // Configure Clerk's JWKS endpoint for key validation
+        options.MetadataAddress = "https://clerk.com/.well-known/jwks.json";
+        
+        options.Events = new JwtBearerEvents
+        {
+            OnAuthenticationFailed = context =>
+            {
+                var logger = context.HttpContext.RequestServices.GetRequiredService<ILogger<Program>>();
+                logger.LogError(context.Exception, "Authentication failed: {Message}", context.Exception.Message);
+                return Task.CompletedTask;
+            },
+            OnTokenValidated = context =>
+            {
+                var logger = context.HttpContext.RequestServices.GetRequiredService<ILogger<Program>>();
+                var userId = context.Principal?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+                logger.LogInformation("Token validated successfully for user: {UserId}", userId);
+                return Task.CompletedTask;
+            }
+        };
+    });
+
+builder.Services.AddAuthorization();
+
 builder.Services.AddControllers();
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
@@ -124,6 +172,8 @@ if (app.Environment.IsDevelopment())
 // Enable CORS - must be before UseAuthorization
 app.UseCors("AllowFrontend");
 
+// Enable authentication and authorization
+app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();


### PR DESCRIPTION
Integrated Clerk authentication to secure all backend API endpoints:

Authentication Configuration:
- Added Clerk.BackendAPI package (v0.15.3)
- Added Microsoft.AspNetCore.Authentication.JwtBearer (v10.0.3)
- Configured JWT Bearer authentication with Clerk's JWKS endpoint
- Token validation against Clerk's public keys
- Environment variable: CLERK_SECRET_KEY (required)

Security Implementation:
- Added [Authorize] attribute to all 12 controllers
- All API endpoints now require valid Clerk JWT token
- Unauthorized requests return 401 Unauthorized
- Authentication middleware validates token issuer and lifetime
- Added authentication event logging for debugging

Protected Controllers:
- CircuitController
- ConstructorController
- ConstructorStandingController
- DriverController
- DriverStandingController
- LapTimingController
- PitStopController
- QualifyingController
- RaceController
- ResultController
- SeasonController
- StatusController

Middleware Pipeline:
- CORS configured before authentication
- UseAuthentication() added before UseAuthorization()
- Proper middleware ordering for security

Frontend Integration:
- Frontend must include JWT token in Authorization header
- Format: Bearer <token>
- Token obtained from Clerk session: session.getToken()

All endpoints are now secure and require authenticated users from Clerk.