### PR TITLE
feat: constructors championship editor, override UI, favicon

### DIFF
--- a/frontEnd/f1-fantasy/index.html
+++ b/frontEnd/f1-fantasy/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>f1-fantasy</title>
   </head>

--- a/frontEnd/f1-fantasy/public/favicon.svg
+++ b/frontEnd/f1-fantasy/public/favicon.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="320"
+   height="80"
+   viewBox="0 0 320 80"
+   fill="none"
+   version="1.1"
+   id="svg16"
+   sodipodi:docname="f1_logo.svg"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview18"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     showgrid="false"
+     inkscape:zoom="3.78125"
+     inkscape:cx="150.08264"
+     inkscape:cy="39.933884"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg16" />
+  <g
+     clip-path="url(#clip0_1_57)"
+     id="g6"
+     style="fill:#de1101;fill-opacity:1">
+    <g
+       clip-path="url(#clip1_1_57)"
+       id="g4"
+       style="fill:#de1101;fill-opacity:1">
+      <path
+         fill-rule="evenodd"
+         clip-rule="evenodd"
+         d="M45.2583 80L80.7417 45.575H80.7333C94.7167 32.0167 100.392 29.9583 127.058 29.9583H233.408L264.008 0H123.025C87.3333 0 77.2417 3.4 56.3083 24.1167L0 80H45.2583ZM127.7 34.7417H228.842L200.792 62.7917H128.225C114.925 62.7917 111.983 63.4167 105.383 70.0167L95.4 80H53.4333L84.4583 48.975C96.6417 36.8 100.842 34.7417 127.7 34.7417ZM320 0L239.783 80H190.175L270.175 0H320ZM267.183 77.4667C268.85 79.1583 270.95 80 273.475 80C276 80 278.075 79.1583 279.717 77.4833C281.358 75.8083 282.175 73.7333 282.175 71.2667C282.175 68.8 281.35 66.725 279.7 65.0333C278.05 63.3417 275.967 62.5 273.442 62.5C270.917 62.5 268.825 63.3417 267.167 65.0167C265.508 66.6917 264.675 68.7667 264.675 71.2333C264.675 73.7 265.508 75.775 267.183 77.4667ZM268.225 66.025C269.625 64.5917 271.358 63.875 273.425 63.875C275.5 63.875 277.233 64.5917 278.625 66.025C280.017 67.4583 280.717 69.2 280.717 71.25C280.717 73.3 280.017 75.0333 278.625 76.4583C277.225 77.8833 275.5 78.5917 273.425 78.5917C271.35 78.5917 269.617 77.875 268.225 76.4417C266.833 75.0083 266.133 73.275 266.133 71.2333C266.133 69.1917 266.833 67.4583 268.225 66.025ZM271.717 76.125V72.6917L271.725 72.7H273.683L275.342 76.1333H277.367L275.542 72.45C276.158 72.1667 276.592 71.8 276.85 71.3417C277.108 70.8833 277.233 70.1833 277.233 69.2417C277.233 68.3 276.917 67.5917 276.283 67.125C275.65 66.65 274.7 66.4167 273.442 66.4167H269.792V76.125H271.717ZM271.683 71.1833V67.9167H273.275C274.65 67.9167 275.333 68.4583 275.333 69.55C275.333 70.125 275.2 70.5417 274.933 70.8C274.675 71.0583 274.242 71.1833 273.642 71.1833H271.683Z"
+         fill="white"
+         id="path2"
+         style="fill:#de1101;fill-opacity:1" />
+    </g>
+  </g>
+  <defs
+     id="defs14">
+    <clipPath
+       id="clip0_1_57">
+      <rect
+         width="320"
+         height="80"
+         fill="white"
+         id="rect8" />
+    </clipPath>
+    <clipPath
+       id="clip1_1_57">
+      <rect
+         width="320"
+         height="80"
+         fill="white"
+         id="rect11" />
+    </clipPath>
+  </defs>
+</svg>

--- a/frontEnd/f1-fantasy/src/molecules/ConstructorsChampionshipEditor.tsx
+++ b/frontEnd/f1-fantasy/src/molecules/ConstructorsChampionshipEditor.tsx
@@ -1,0 +1,168 @@
+import { useState } from "react";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { HolderOutlined } from "@ant-design/icons";
+import { F1Button, F1Text } from "../atoms";
+import { useConstructors, useConstructorsFromApi } from "../state/useDriversAndConstructors";
+import type { ConstructorsChampionshipPrediction } from "../types/predictions";
+
+function SortableConstructorRow({
+  constructorId,
+  position,
+  constructorName,
+}: {
+  constructorId: string;
+  position: number;
+  constructorName: string;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: constructorId });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <tr
+      ref={setNodeRef}
+      style={style}
+      className={`border-b border-f1-gray/50 ${isDragging ? "opacity-50 bg-f1-gray/50 z-10" : ""}`}
+    >
+      <td className="py-1.5 pr-3 tabular-nums text-f1-silver/80 w-10">{position}</td>
+      <td className="py-1.5 pr-2">
+        <span
+          className="inline-flex cursor-grab touch-none items-center gap-2 active:cursor-grabbing"
+          {...attributes}
+          {...listeners}
+        >
+          <HolderOutlined className="text-f1-silver/60" />
+          <span className="text-f1-silver">{constructorName}</span>
+        </span>
+      </td>
+    </tr>
+  );
+}
+
+type ConstructorsChampionshipEditorProps = {
+  value: ConstructorsChampionshipPrediction | undefined;
+  onSave: (prediction: ConstructorsChampionshipPrediction) => void;
+};
+
+export function ConstructorsChampionshipEditor({ value, onSave }: ConstructorsChampionshipEditorProps) {
+  const constructors = useConstructors();
+  const fromApi = useConstructorsFromApi();
+  const sorted = (value ?? []).slice().sort((a, b) => a.position - b.position);
+  const existingIds = sorted.map((e) => e.constructorId);
+  const missingIds = constructors.map((c) => c.id).filter((id) => !existingIds.includes(id));
+  const count = constructors.length;
+  const [constructorOrder, setConstructorOrder] = useState<string[]>(() => {
+    if (existingIds.length >= count) return existingIds.slice(0, count);
+    return [...existingIds, ...missingIds].slice(0, count);
+  });
+  const getConstructorName = (id: string) => constructors.find((c) => c.id === id)?.name ?? id;
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (over == null || active.id === over.id) return;
+    setConstructorOrder((prev) => {
+      const oldIndex = prev.indexOf(active.id as string);
+      const newIndex = prev.indexOf(over.id as string);
+      if (oldIndex === -1 || newIndex === -1) return prev;
+      return arrayMove(prev, oldIndex, newIndex);
+    });
+  };
+
+  const handleSave = () => {
+    const prediction: ConstructorsChampionshipPrediction = constructorOrder.map((constructorId, i) => ({
+      position: i + 1,
+      constructorId,
+    }));
+    onSave(prediction);
+  };
+
+  const isValid =
+    constructorOrder.length === count &&
+    new Set(constructorOrder).size === count &&
+    constructorOrder.every((id) => constructors.some((c) => c.id === id));
+
+  if (constructors.length === 0) {
+    return (
+      <div className="space-y-2">
+        <F1Text muted className="block text-sm">
+          No constructors loaded. Set <code className="rounded bg-f1-gray px-1 text-xs">VITE_API_BASE_URL</code> and ensure
+          the constructors API returns data for the current season, or add mock constructors for development.
+        </F1Text>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <F1Text muted className="block text-xs">
+        {`Drag constructors to reorder. Top = P1, bottom = P${count}.`}
+        {fromApi
+          ? ` (${constructors.length} constructors from API)`
+          : ` (${constructors.length} constructors — offline list; set API to use live data)`}
+      </F1Text>
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <div className="min-w-0 overflow-x-auto">
+          <table className="w-full min-w-[200px] text-sm">
+            <thead>
+              <tr className="border-b border-f1-gray text-left text-f1-silver/70">
+                <th className="py-1 pr-3 font-normal w-10">Pos</th>
+                <th className="py-1 font-normal">Constructor</th>
+              </tr>
+            </thead>
+            <tbody>
+              <SortableContext items={constructorOrder} strategy={verticalListSortingStrategy}>
+                {constructorOrder.map((constructorId, i) => (
+                  <SortableConstructorRow
+                    key={constructorId}
+                    constructorId={constructorId}
+                    position={i + 1}
+                    constructorName={getConstructorName(constructorId)}
+                  />
+                ))}
+              </SortableContext>
+            </tbody>
+          </table>
+        </div>
+      </DndContext>
+      <F1Button type="primary" onClick={handleSave} disabled={!isValid}>
+        Save prediction
+      </F1Button>
+      {!isValid && constructorOrder.length < count && (
+        <F1Text muted className="block text-xs">
+          Add all {count} constructors (drag to reorder; list must be complete to save).
+        </F1Text>
+      )}
+    </div>
+  );
+}

--- a/frontEnd/f1-fantasy/src/organisms/CategoryDetailView.tsx
+++ b/frontEnd/f1-fantasy/src/organisms/CategoryDetailView.tsx
@@ -3,6 +3,7 @@ import { ArrowLeftOutlined } from "@ant-design/icons";
 import { F1Button, F1Title, F1Text, F1Card } from "../atoms";
 import { PredictionContent, getDriverName, getConstructorName } from "../molecules/YourPredictionContent";
 import { DriversChampionshipEditor } from "../molecules/DriversChampionshipEditor";
+import { ConstructorsChampionshipEditor } from "../molecules/ConstructorsChampionshipEditor";
 import { TwoDriverPicker } from "../molecules/TwoDriverPicker";
 import { ZeroPointersEditor } from "../molecules/ZeroPointersEditor";
 import { CATEGORY_LABELS, CATEGORY_DESCRIPTIONS } from "../constants/predictionCategories";
@@ -166,6 +167,15 @@ export function CategoryDetailView({ group, categoryId, data, setData, currentUs
     }));
   };
 
+  const handleSaveConstructorsChampionship = (constructorsChampionship: { position: number; constructorId: string }[]) => {
+    setData((prev) => ({
+      ...prev,
+      predictions: prev.predictions.map((p) =>
+        p.userId === currentUserId ? { ...p, constructorsChampionship } : p
+      ),
+    }));
+  };
+
   const handleSaveDriverDraft = (driverDraft: { driverId1: string; driverId2: string }) => {
     setData((prev) => ({
       ...prev,
@@ -247,6 +257,11 @@ export function CategoryDetailView({ group, categoryId, data, setData, currentUs
                 <DriversChampionshipEditor
                   value={myPredictions?.driversChampionship}
                   onSave={handleSaveDriversChampionship}
+                />
+              ) : categoryId === "constructorsChampionship" ? (
+                <ConstructorsChampionshipEditor
+                  value={myPredictions?.constructorsChampionship}
+                  onSave={handleSaveConstructorsChampionship}
                 />
               ) : categoryId === "driverDraft" ? (
                 <TwoDriverPicker

--- a/frontEnd/f1-fantasy/src/organisms/GroupPredictionsView.tsx
+++ b/frontEnd/f1-fantasy/src/organisms/GroupPredictionsView.tsx
@@ -9,7 +9,6 @@ import {
   isUserLocked,
   canUserUnlockSelf,
   getEffectiveGroupLocked,
-  getSystemPredictionsLocked,
   isGroupAdmin,
 } from "../utils/predictionLock";
 import type { Group } from "../types/group";
@@ -62,23 +61,14 @@ export function GroupPredictionsView({
     setData((prev) => ({ ...prev, adminSetPredictionsLocked: false }));
   };
 
-  const handleAdminOverrideLock = () => {
-    setData((prev) => ({ ...prev, adminLockOverride: true }));
-  };
-
-  const handleAdminOverrideUnlock = () => {
-    setData((prev) => ({ ...prev, adminLockOverride: false }));
-  };
-
-  const handleAdminClearOverride = () => {
-    setData((prev) => ({ ...prev, adminLockOverride: undefined }));
+  const handleAdminOverrideToggle = () => {
+    setData((prev) => ({ ...prev, adminLockOverride: !groupLocked }));
   };
 
   const handleCategoryClick = (categoryId: PredictionCategoryId) => {
     setSelectedCategoryId(categoryId);
   };
 
-  const systemLocked = getSystemPredictionsLocked(data);
   const showAdminGroupToggle = isAdmin && mode === "admin";
   const showAdminOverride = isAdmin && mode === "hybrid";
 
@@ -104,27 +94,10 @@ export function GroupPredictionsView({
               )}
             </>
           )}
-          {showAdminOverride && (
-            <>
-              <F1Text muted className="text-sm">
-                System: {systemLocked ? "locked" : "unlocked"}
-                {data.adminLockOverride !== undefined && ` · Override: ${data.adminLockOverride ? "locked" : "unlocked"}`}
-              </F1Text>
-              {data.adminLockOverride === undefined ? (
-                <>
-                  <F1Button type="default" size="small" icon={<LockOutlined />} onClick={handleAdminOverrideLock}>
-                    Override: lock
-                  </F1Button>
-                  <F1Button type="default" size="small" icon={<UnlockOutlined />} onClick={handleAdminOverrideUnlock}>
-                    Override: unlock
-                  </F1Button>
-                </>
-              ) : (
-                <F1Button type="default" size="small" onClick={handleAdminClearOverride}>
-                  Use system default
-                </F1Button>
-              )}
-            </>
+          {showAdminOverride && groupLocked && (
+            <F1Button type="default" size="small" icon={<UnlockOutlined />} onClick={handleAdminOverrideToggle}>
+              Unlock predictions
+            </F1Button>
           )}
           {!groupLocked && (
             <>


### PR DESCRIPTION
- Add ConstructorsChampionshipEditor (drag-and-drop, no hard cap on count)
- Wire constructors championship in CategoryDetailView with save handler
- Simplify hybrid override: single 'Unlock predictions' button when locked only
- F1 logo favicon from Wikimedia Commons; index.html points to /favicon.svg