### PR TITLE
feat: wildcard admin controls, modal fix, API auth resilience

### DIFF
--- a/frontEnd/f1-fantasy/docs/DATA_STRUCTURES_FOR_BACKEND.md
+++ b/frontEnd/f1-fantasy/docs/DATA_STRUCTURES_FOR_BACKEND.md
@@ -69,7 +69,7 @@ interface UserPredictions {
 | destructors              | `{ driverId1: string; driverId2: string }` |
 | mrSaturday               | `{ driverId1: string; driverId2: string }` |
 | zeroPointers             | `{ driverIds: string[] }` — length 0 to grid size (e.g. 0–22). |
-| wildcard                  | `{ statement: string }` — free text. |
+| wildcard                  | `{ statement: string; pointsPotential?: number; fulfilled?: boolean }` — one per user. Admin sets `pointsPotential` (higher = more “unhinged” = higher score if fulfilled) and ticks `fulfilled` when it comes true so points count. |
 
 **Examples:**
 

--- a/frontEnd/f1-fantasy/src/App.tsx
+++ b/frontEnd/f1-fantasy/src/App.tsx
@@ -19,10 +19,13 @@ const f1Theme = {
 /** Registers Clerk session token with the API client so requests send Authorization: Bearer <token>. */
 function ApiAuthSetup() {
     const { getToken } = useAuth();
+    const jwtTemplate = import.meta.env.VITE_CLERK_JWT_TEMPLATE as string | undefined;
     useEffect(() => {
-        setAuthTokenGetter(() => getToken());
+        setAuthTokenGetter(() =>
+            jwtTemplate ? getToken({ template: jwtTemplate }) : getToken()
+        );
         return () => setAuthTokenGetter(null);
-    }, [getToken]);
+    }, [getToken, jwtTemplate]);
     return null;
 }
 

--- a/frontEnd/f1-fantasy/src/api/client.ts
+++ b/frontEnd/f1-fantasy/src/api/client.ts
@@ -15,8 +15,12 @@ export function getApiBaseUrl(): string | undefined {
 async function getAuthHeaders(): Promise<Record<string, string>> {
   const headers: Record<string, string> = { Accept: "application/json" };
   if (authTokenGetter) {
-    const token = await authTokenGetter();
-    if (token) headers.Authorization = `Bearer ${token}`;
+    try {
+      const token = await authTokenGetter();
+      if (token) headers.Authorization = `Bearer ${token}`;
+    } catch (_err) {
+      // Session may be expired or getToken failed; proceed without token so caller can handle 401
+    }
   }
   return headers;
 }

--- a/frontEnd/f1-fantasy/src/molecules/CreateGroupModal.tsx
+++ b/frontEnd/f1-fantasy/src/molecules/CreateGroupModal.tsx
@@ -100,7 +100,7 @@ export function CreateGroupModal({ open, onClose, onCreated, currentUserId }: Cr
       open={open}
       onCancel={handleCancel}
       footer={null}
-      destroyOnClose
+      destroyOnHidden
       width={460}
       centered
       className="create-group-modal max-w-[calc(100vw-2rem)] [&_.ant-modal-content]:overflow-hidden [&_.ant-modal-content]:rounded-2xl [&_.ant-modal-content]:border [&_.ant-modal-content]:border-f1-gray [&_.ant-modal-content]:bg-f1-carbon [&_.ant-modal-content]:shadow-[0_24px_48px_-12px_rgba(0,0,0,0.6)] [&_.ant-modal-header]:border-f1-gray [&_.ant-modal-header]:bg-transparent [&_.ant-modal-body]:pt-6 [&_.ant-modal-close]:text-f1-silver [&_.ant-modal-close]:hover:text-f1-white"

--- a/frontEnd/f1-fantasy/src/molecules/JoinGroupModal.tsx
+++ b/frontEnd/f1-fantasy/src/molecules/JoinGroupModal.tsx
@@ -61,7 +61,7 @@ export function JoinGroupModal({
       open={open}
       onCancel={handleCancel}
       footer={null}
-      destroyOnClose
+      destroyOnHidden
       width={400}
       centered
       className="!max-w-[calc(100vw-2rem)] [&_.ant-modal-content]:border [&_.ant-modal-content]:border-f1-gray [&_.ant-modal-content]:bg-f1-carbon [&_.ant-modal-header]:border-f1-gray [&_.ant-modal-header]:bg-transparent [&_.ant-modal-body]:pt-2"

--- a/frontEnd/f1-fantasy/src/molecules/WildcardEditor.tsx
+++ b/frontEnd/f1-fantasy/src/molecules/WildcardEditor.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { Input } from "antd";
+import { F1Button, F1Text } from "../atoms";
+import type { WildcardPrediction } from "../types/predictions";
+
+const { TextArea } = Input;
+
+type WildcardEditorProps = {
+  value: WildcardPrediction | undefined;
+  onSave: (prediction: WildcardPrediction) => void;
+};
+
+/** One wildcard prediction per user: single statement. */
+export function WildcardEditor({ value, onSave }: WildcardEditorProps) {
+  const [statement, setStatement] = useState(value?.statement ?? "");
+  const trimmed = statement.trim();
+
+  const handleSave = () => {
+    if (!trimmed) return;
+    onSave({ ...value, statement: trimmed });
+  };
+
+  return (
+    <div className="space-y-4">
+      <F1Text muted className="block text-xs">
+        One wildcard prediction per user. The bolder the claim, the more points the admin can assign if it comes true.
+      </F1Text>
+      <TextArea
+        value={statement}
+        onChange={(e) => setStatement(e.target.value)}
+        placeholder="e.g. Piastri wins a race, or Haas scores a podium..."
+        rows={3}
+        maxLength={500}
+        showCount
+        className="bg-f1-gray/80 border-f1-gray text-f1-silver placeholder:text-f1-silver/50"
+      />
+      <F1Button type="primary" onClick={handleSave} disabled={!trimmed}>
+        Save wildcard
+      </F1Button>
+    </div>
+  );
+}

--- a/frontEnd/f1-fantasy/src/molecules/YourPredictionContent.tsx
+++ b/frontEnd/f1-fantasy/src/molecules/YourPredictionContent.tsx
@@ -127,7 +127,15 @@ function PredictionContent({ predictions, categoryId, drivers, constructors }: P
     case "wildcard": {
       const p = predictions.wildcard;
       if (!p?.statement) return <F1Text muted>No prediction yet.</F1Text>;
-      return <F1Text className="italic">"{p.statement}"</F1Text>;
+      return (
+        <span>
+          <F1Text className="italic">"{p.statement}"</F1Text>
+          {p.pointsPotential != null && (
+            <F1Text muted className="ml-2 text-xs">({p.pointsPotential} pts max)</F1Text>
+          )}
+          {p.fulfilled && <F1Text className="ml-2 text-xs text-f1-gold">✓ Fulfilled</F1Text>}
+        </span>
+      );
     }
     default:
       return null;

--- a/frontEnd/f1-fantasy/src/organisms/CategoryDetailView.tsx
+++ b/frontEnd/f1-fantasy/src/organisms/CategoryDetailView.tsx
@@ -1,18 +1,21 @@
 import { useSetRecoilState } from "recoil";
 import { ArrowLeftOutlined } from "@ant-design/icons";
+import { InputNumber, Checkbox } from "antd";
 import { F1Button, F1Title, F1Text, F1Card } from "../atoms";
 import { PredictionContent, getDriverName, getConstructorName } from "../molecules/YourPredictionContent";
 import { DriversChampionshipEditor } from "../molecules/DriversChampionshipEditor";
 import { ConstructorsChampionshipEditor } from "../molecules/ConstructorsChampionshipEditor";
 import { TwoDriverPicker } from "../molecules/TwoDriverPicker";
 import { ZeroPointersEditor } from "../molecules/ZeroPointersEditor";
+import { WildcardEditor } from "../molecules/WildcardEditor";
 import { CATEGORY_LABELS, CATEGORY_DESCRIPTIONS } from "../constants/predictionCategories";
 import { selectedCategoryIdState } from "../state/atoms";
 import { useDrivers, useConstructors } from "../state/useDriversAndConstructors";
-import { isUserLocked } from "../utils/predictionLock";
+import { isUserLocked, isGroupAdmin } from "../utils/predictionLock";
 import type { Group } from "../types/group";
 import type { PredictionCategoryId } from "../types/predictions";
 import type { GroupPredictionsData } from "../types/predictions";
+import type { WildcardPrediction } from "../types/predictions";
 import type { Driver } from "../types/driver";
 import type { Constructor } from "../types/constructor";
 
@@ -212,6 +215,33 @@ export function CategoryDetailView({ group, categoryId, data, setData, currentUs
     }));
   };
 
+  const handleSaveWildcard = (wildcard: WildcardPrediction) => {
+    setData((prev) => ({
+      ...prev,
+      predictions: prev.predictions.map((p) =>
+        p.userId === currentUserId ? { ...p, wildcard } : p
+      ),
+    }));
+  };
+
+  const handleAdminSetWildcard = (
+    userId: string,
+    updates: { pointsPotential?: number; fulfilled?: boolean }
+  ) => {
+    setData((prev) => ({
+      ...prev,
+      predictions: prev.predictions.map((p) => {
+        if (p.userId !== userId || !p.wildcard) return p;
+        return {
+          ...p,
+          wildcard: { ...p.wildcard, ...updates },
+        };
+      }),
+    }));
+  };
+
+  const isAdmin = isGroupAdmin(group, currentUserId);
+
   return (
     <div className="min-w-0 space-y-6">
       <F1Button
@@ -286,8 +316,13 @@ export function CategoryDetailView({ group, categoryId, data, setData, currentUs
                   value={myPredictions?.zeroPointers}
                   onSave={handleSaveZeroPointers}
                 />
+              ) : categoryId === "wildcard" ? (
+                <WildcardEditor
+                  value={myPredictions?.wildcard}
+                  onSave={handleSaveWildcard}
+                />
               ) : (
-<>
+                <>
                   <PredictionContent predictions={myPredictions} categoryId={categoryId} drivers={drivers} constructors={constructors} />
                   <p className="mt-2 text-xs text-f1-silver/70">Editing for this category is not available yet.</p>
                 </>
@@ -313,6 +348,56 @@ export function CategoryDetailView({ group, categoryId, data, setData, currentUs
             currentUserId={currentUserId}
             constructors={constructors}
           />
+        ) : categoryId === "wildcard" ? (
+          <div className="flex flex-col gap-4">
+            {data.predictions.map((userPrediction) => {
+              const w = userPrediction.wildcard;
+              const score = data.standings
+                .find((s) => s.userId === userPrediction.userId)
+                ?.categoryScores.find((c) => c.categoryId === "wildcard")?.score;
+              return (
+                <F1Card key={userPrediction.userId} className="!rounded-lg">
+                  <div className="flex flex-wrap items-start justify-between gap-2">
+                    <F1Text className={userPrediction.userId === currentUserId ? "text-f1-red font-medium" : ""}>
+                      {getFirstName(userPrediction.displayName)}
+                      {userPrediction.userId === currentUserId ? " (you)" : ""}
+                    </F1Text>
+                    {score !== undefined && (
+                      <span className="text-f1-gold font-mono text-sm">{score} pts</span>
+                    )}
+                  </div>
+                  <div className="mt-2 pt-2 border-t border-f1-gray">
+                    {w?.statement ? (
+                      <F1Text className="italic">"{w.statement}"</F1Text>
+                    ) : (
+                      <F1Text muted>No wildcard yet.</F1Text>
+                    )}
+                    {isAdmin && w?.statement && (
+                      <div className="mt-3 flex flex-wrap items-center gap-4">
+                        <label className="flex items-center gap-2 text-sm text-f1-silver">
+                          <span>Points potential:</span>
+                          <InputNumber
+                            min={1}
+                            max={100}
+                            value={w.pointsPotential ?? 10}
+                            onChange={(val) => handleAdminSetWildcard(userPrediction.userId, { pointsPotential: val ?? undefined })}
+                            className="w-20 bg-f1-gray border-f1-gray text-f1-silver [&_.ant-input-number-input]:bg-transparent"
+                          />
+                        </label>
+                        <Checkbox
+                          checked={w.fulfilled ?? false}
+                          onChange={(e) => handleAdminSetWildcard(userPrediction.userId, { fulfilled: e.target.checked })}
+                          className="text-f1-silver [&_.ant-checkbox-inner]:border-f1-gray [&_.ant-checkbox-checked_.ant-checkbox-inner]:bg-f1-red [&_.ant-checkbox-checked_.ant-checkbox-inner]:border-f1-red"
+                        >
+                          Fulfilled (came true)
+                        </Checkbox>
+                      </div>
+                    )}
+                  </div>
+                </F1Card>
+              );
+            })}
+          </div>
         ) : (
           <div className="flex flex-col gap-4">
             {data.predictions.map((userPrediction) => (

--- a/frontEnd/f1-fantasy/src/types/predictions.ts
+++ b/frontEnd/f1-fantasy/src/types/predictions.ts
@@ -26,8 +26,14 @@ export type MrSaturdayPrediction = { driverId1: string; driverId2: string };
 /** 0 Pointers: drivers predicted to finish with 0 points */
 export type ZeroPointersPrediction = { driverIds: string[] };
 
-/** Wildcard: free-form statement; points if it comes true */
-export type WildcardPrediction = { statement: string };
+/** Wildcard: one free-form statement per user; points if it comes true. Admin sets points potential and marks fulfilled. */
+export type WildcardPrediction = {
+  statement: string;
+  /** Admin-set: higher = more "unhinged" prediction, higher score potential when fulfilled. */
+  pointsPotential?: number;
+  /** Admin ticks when prediction has come true so points can be counted. */
+  fulfilled?: boolean;
+};
 
 export interface UserPredictions {
   userId: string;


### PR DESCRIPTION
- Wildcard: admin sets points potential (int) and marks fulfilled; one per user
- WildcardEditor + admin controls in CategoryDetailView (points input, fulfilled checkbox)
- Modal: destroyOnClose -> destroyOnHidden (antd deprecation)
- API client: try/catch around getToken; optional VITE_CLERK_JWT_TEMPLATE for backend
- DATA_STRUCTURES_FOR_BACKEND: wildcard type and docs