### PR TITLE
Fix EF Core Include error in GetGroupsByUserIdAsync

### DIFF
--- a/backend/F1Fantasy/Repository/GroupRepository.cs
+++ b/backend/F1Fantasy/Repository/GroupRepository.cs
@@ -36,9 +36,8 @@ public class GroupRepository
 
     public async Task<List<Group>> GetGroupsByUserIdAsync(string userId)
     {
-        return await _context.GroupMembers
-            .Where(gm => gm.UserId == userId)
-            .Select(gm => gm.Group)
+        return await _context.Groups
+            .Where(g => g.Members.Any(m => m.UserId == userId))
             .Include(g => g.Members)
             .ToListAsync();
     }


### PR DESCRIPTION
Changed from Select().Include() to Where(Any()).Include() pattern to comply with EF Core requirements that Include must come before Select when changing entity types.

Frontend was receiving error: "Cannot apply the 'Include' operation to the result of a 'Select' projection."

Before: _context.GroupMembers.Where().Select(gm => gm.Group).Include(g => g.Members)
After: _context.Groups.Where(g => g.Members.Any(m => m.UserId == userId)).Include(g => g.Members)

This approach queries Groups directly and filters by membership, allowing proper eager loading of navigation properties.