### PR TITLE
fix: correct lock mode validation values

### DIFF
--- a/backend/F1Fantasy/Controllers/GroupsController.cs
+++ b/backend/F1Fantasy/Controllers/GroupsController.cs
@@ -247,7 +247,7 @@ public record CreateGroupRequest(
     [RegularExpression(@"^[^<>]*$", ErrorMessage = "Group name contains invalid characters")]
     string Name,
     
-    [RegularExpression(@"^(manual|auto|never)$", ErrorMessage = "Lock mode must be 'manual', 'auto', or 'never'")]
+    [RegularExpression(@"^(admin|system|hybrid)$", ErrorMessage = "Lock mode must be 'admin', 'system', or 'hybrid'")]
     string LockMode
 );
 

--- a/backend/F1Fantasy/Services/GroupService.cs
+++ b/backend/F1Fantasy/Services/GroupService.cs
@@ -17,7 +17,6 @@ public class GroupService
     {
         // Validate inputs
         ValidationExtensions.ValidateGroupName(name);
-        ValidationExtensions.ValidateLockMode(lockMode);
 
         // Generate unique invite code
         var inviteCode = GenerateInviteCode();

--- a/backend/F1Fantasy/Validation/ValidationExtensions.cs
+++ b/backend/F1Fantasy/Validation/ValidationExtensions.cs
@@ -102,16 +102,4 @@ public static class ValidationExtensions
             throw new ArgumentException($"Season must be between 1950 and {DateTime.UtcNow.Year + 1}");
         }
     }
-
-    /// <summary>
-    /// Validates lock mode is a valid enum value
-    /// </summary>
-    public static void ValidateLockMode(string lockMode)
-    {
-        var validModes = new[] { "admin", "system", "hybrid" };
-        if (!validModes.Contains(lockMode.ToLower()))
-        {
-            throw new ArgumentException($"Lock mode must be one of: {string.Join(", ", validModes)}");
-        }
-    }
 }


### PR DESCRIPTION
- Fixed GroupsController DTO validation: manual|auto|never  admin|system|hybrid
- Removed redundant ValidateLockMode service-layer validation
- Deleted unused ValidateLockMode helper method
- DTO RegularExpression attribute now handles validation at API boundary