### PR TITLE
fix: prevent JSON serialization cycle in Group navigation properties

### DIFF
--- a/backend/F1Fantasy/Models/ConstructorChampionshipPrediction.cs
+++ b/backend/F1Fantasy/Models/ConstructorChampionshipPrediction.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace F1Fantasy.Models;
 
 public class ConstructorChampionshipPrediction
@@ -13,5 +15,6 @@ public class ConstructorChampionshipPrediction
     public DateTime? UpdatedAt { get; set; }
 
     // Navigation property
+    [JsonIgnore]
     public Group Group { get; set; } = null!;
 }

--- a/backend/F1Fantasy/Models/DestructorPrediction.cs
+++ b/backend/F1Fantasy/Models/DestructorPrediction.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace F1Fantasy.Models;
 
 public class DestructorPrediction
@@ -14,5 +16,6 @@ public class DestructorPrediction
     public DateTime? UpdatedAt { get; set; }
 
     // Navigation property
+    [JsonIgnore]
     public Group Group { get; set; } = null!;
 }

--- a/backend/F1Fantasy/Models/DriverChampionshipPrediction.cs
+++ b/backend/F1Fantasy/Models/DriverChampionshipPrediction.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace F1Fantasy.Models;
 
 public class DriverChampionshipPrediction
@@ -13,5 +15,6 @@ public class DriverChampionshipPrediction
     public DateTime? UpdatedAt { get; set; }
 
     // Navigation property
+    [JsonIgnore]
     public Group Group { get; set; } = null!;
 }

--- a/backend/F1Fantasy/Models/DriverDraftPrediction.cs
+++ b/backend/F1Fantasy/Models/DriverDraftPrediction.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace F1Fantasy.Models;
 
 public class DriverDraftPrediction
@@ -13,5 +15,6 @@ public class DriverDraftPrediction
     public DateTime? UpdatedAt { get; set; }
 
     // Navigation property
+    [JsonIgnore]
     public Group Group { get; set; } = null!;
 }

--- a/backend/F1Fantasy/Models/GroupMember.cs
+++ b/backend/F1Fantasy/Models/GroupMember.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace F1Fantasy.Models;
 
 public class GroupMember
@@ -8,5 +10,6 @@ public class GroupMember
     public DateTime JoinedAt { get; set; }
 
     // Navigation property
+    [JsonIgnore]
     public Group Group { get; set; } = null!;
 }

--- a/backend/F1Fantasy/Models/MrSaturdayPrediction.cs
+++ b/backend/F1Fantasy/Models/MrSaturdayPrediction.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace F1Fantasy.Models;
 
 public class MrSaturdayPrediction
@@ -14,5 +16,6 @@ public class MrSaturdayPrediction
     public DateTime? UpdatedAt { get; set; }
 
     // Navigation property
+    [JsonIgnore]
     public Group Group { get; set; } = null!;
 }

--- a/backend/F1Fantasy/Models/Standing.cs
+++ b/backend/F1Fantasy/Models/Standing.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace F1Fantasy.Models;
 
 public class Standing
@@ -15,5 +17,6 @@ public class Standing
     public DateTime UpdatedAt { get; set; }
 
     // Navigation property
+    [JsonIgnore]
     public Group Group { get; set; } = null!;
 }

--- a/backend/F1Fantasy/Models/WildcardPrediction.cs
+++ b/backend/F1Fantasy/Models/WildcardPrediction.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace F1Fantasy.Models;
 
 public class WildcardPrediction
@@ -14,5 +16,6 @@ public class WildcardPrediction
     public DateTime? UpdatedAt { get; set; }
 
     // Navigation property
+    [JsonIgnore]
     public Group Group { get; set; } = null!;
 }

--- a/backend/F1Fantasy/Models/ZeroPointerPrediction.cs
+++ b/backend/F1Fantasy/Models/ZeroPointerPrediction.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace F1Fantasy.Models;
 
 public class ZeroPointerPrediction
@@ -13,5 +15,6 @@ public class ZeroPointerPrediction
     public DateTime? UpdatedAt { get; set; }
 
     // Navigation property
+    [JsonIgnore]
     public Group Group { get; set; } = null!;
 }


### PR DESCRIPTION
Added [JsonIgnore] attribute to Group navigation properties in all models to prevent infinite recursion during JSON serialization.

Fixes: POST /api/groups throwing JsonException (object cycle detected)

Files updated:
- GroupMember.cs
- ConstructorChampionshipPrediction.cs
- DriverChampionshipPrediction.cs
- DriverDraftPrediction.cs
- DestructorPrediction.cs
- MrSaturdayPrediction.cs
- ZeroPointerPrediction.cs
- WildcardPrediction.cs
- Standing.cs

Root cause: Group.Members collection references GroupMember entities, which each have a Group navigation property, creating a cycle (Group  Members  Group  Members...).

Solution: Ignore Group navigation property during serialization. The GroupId foreign key is sufficient for API responses.