### PR TITLE
fix: replace Forbid() with StatusCode(403) and ensure group deletion …

### DIFF
--- a/backend/F1Fantasy/Controllers/AdminController.cs
+++ b/backend/F1Fantasy/Controllers/AdminController.cs
@@ -40,7 +40,7 @@ public class AdminController : ControllerBase
             var adminUserId = GetUserId();
             if (!await IsGroupAdminAsync(groupId, adminUserId))
             {
-                return Forbid("Only group admin can set wildcard points");
+                return StatusCode(403, new { error = "Only group admin can set wildcard points" });
             }
 
             if (request.PointsPotential < 100 || request.PointsPotential > 200)
@@ -73,7 +73,7 @@ public class AdminController : ControllerBase
             var adminUserId = GetUserId();
             if (!await IsGroupAdminAsync(groupId, adminUserId))
             {
-                return Forbid("Only group admin can mark wildcard as fulfilled");
+                return StatusCode(403, new { error = "Only group admin can mark wildcard as fulfilled" });
             }
 
             var prediction = await _predictionRepository.GetWildcardAsync(groupId, userId);
@@ -101,7 +101,7 @@ public class AdminController : ControllerBase
             var adminUserId = GetUserId();
             if (!await IsGroupAdminAsync(groupId, adminUserId))
             {
-                return Forbid("Only group admin can view all wildcards");
+                return StatusCode(403, new { error = "Only group admin can view all wildcards" });
             }
 
             var wildcards = await _predictionRepository.GetAllWildcardsAsync(groupId);

--- a/backend/F1Fantasy/Controllers/GroupsController.cs
+++ b/backend/F1Fantasy/Controllers/GroupsController.cs
@@ -137,7 +137,7 @@ public class GroupsController : ControllerBase
         }
         catch (UnauthorizedAccessException ex)
         {
-            return Forbid(ex.Message);
+            return StatusCode(403, new { error = ex.Message });
         }
         catch (ArgumentException ex)
         {
@@ -164,7 +164,7 @@ public class GroupsController : ControllerBase
         }
         catch (UnauthorizedAccessException ex)
         {
-            return Forbid(ex.Message);
+            return StatusCode(403, new { error = ex.Message });
         }
         catch (Exception ex)
         {
@@ -183,7 +183,7 @@ public class GroupsController : ControllerBase
         }
         catch (UnauthorizedAccessException ex)
         {
-            return Forbid(ex.Message);
+            return StatusCode(403, new { error = ex.Message });
         }
         catch (InvalidOperationException ex)
         {
@@ -210,7 +210,7 @@ public class GroupsController : ControllerBase
         }
         catch (UnauthorizedAccessException ex)
         {
-            return Forbid(ex.Message);
+            return StatusCode(403, new { error = ex.Message });
         }
         catch (Exception ex)
         {
@@ -229,7 +229,7 @@ public class GroupsController : ControllerBase
         }
         catch (UnauthorizedAccessException ex)
         {
-            return Forbid(ex.Message);
+            return StatusCode(403, new { error = ex.Message });
         }
         catch (InvalidOperationException ex)
         {

--- a/backend/F1Fantasy/Repository/GroupRepository.cs
+++ b/backend/F1Fantasy/Repository/GroupRepository.cs
@@ -58,10 +58,18 @@ public class GroupRepository
 
     public async Task DeleteAsync(int id)
     {
-        var group = await _context.Groups.FindAsync(id);
+        var group = await _context.Groups
+            .Include(g => g.Members)
+            .FirstOrDefaultAsync(g => g.Id == id);
+        
         if (group != null)
         {
+            // Explicitly remove all members first to ensure cascade works
+            _context.GroupMembers.RemoveRange(group.Members);
+            
+            // Then remove the group
             _context.Groups.Remove(group);
+            
             await _context.SaveChangesAsync();
         }
     }


### PR DESCRIPTION
…works

Fixed two critical issues:

1. Authentication Handler Error
   - Forbid() expects an authentication scheme name, not an error message
   - Changed all Forbid(message) calls to StatusCode(403, new { error = message })
   - Affected endpoints: GroupsController (RenameGroup, DeleteGroup, RemoveMember, Lock/Unlock)
   - Affected endpoints: AdminController (SetWildcardPoints, SetWildcardFulfilled, GetAllWildcards)

2. Group Not Deleting Properly
   - GroupRepository.DeleteAsync() now explicitly removes members first
   - Ensures cascade delete completes before SaveChanges()
   - Prevents orphaned GroupMember records from causing deleted groups to appear in GET /groups

Files changed:
- Controllers/GroupsController.cs
- Controllers/AdminController.cs
- Repository/GroupRepository.cs