### PR TITLE
fix: disable browser caching for /groups endpoints

### DIFF
--- a/backend/F1Fantasy/Middleware/CacheHeaderMiddleware.cs
+++ b/backend/F1Fantasy/Middleware/CacheHeaderMiddleware.cs
@@ -66,7 +66,9 @@ public class CacheHeaderMiddleware
     /// </summary>
     private bool ShouldCacheModerately(string path)
     {
-        return path.Contains("/groups") && !path.Contains("/standings");
+        // Disabled caching for /groups due to delete/update issues
+        // Users were seeing deleted groups due to 5-minute cache
+        return false; // path.Contains("/groups") && !path.Contains("/standings");
     }
 
     /// <summary>


### PR DESCRIPTION
Disabled moderate caching (5-minute max-age) for /groups endpoints to prevent browsers from serving stale data after deletions. Users were seeing phantom deleted groups due to Cache-Control headers causing browser to cache responses for 300 seconds.

This fix ensures /groups responses are always fresh, preventing confusion when groups are deleted or updated.