### PR TITLE
fix: validate predictions against active season drivers/constructors …

### DIFF
--- a/backend/F1Fantasy/Repository/ConstructorRepository.cs
+++ b/backend/F1Fantasy/Repository/ConstructorRepository.cs
@@ -39,6 +39,24 @@ public class ConstructorRepository
         return await _context.Constructors.OrderBy(c => c.Name).ToListAsync();
     }
 
+    public async Task<IEnumerable<Constructor>> GetActiveConstructorsAsync(string? season = null)
+    {
+        // Use current year if season not specified
+        season ??= DateTime.UtcNow.Year.ToString();
+        
+        // Get constructors that have standings in the current season
+        var activeConstructorIds = await _context.ConstructorStandings
+            .Where(cs => cs.Season == season)
+            .Select(cs => cs.ConstructorId)
+            .Distinct()
+            .ToListAsync();
+        
+        return await _context.Constructors
+            .Where(c => activeConstructorIds.Contains(c.ConstructorId))
+            .OrderBy(c => c.Name)
+            .ToListAsync();
+    }
+
     public async Task ClearAsync()
     {
         _context.Constructors.RemoveRange(_context.Constructors);

--- a/backend/F1Fantasy/Repository/DriverRepository.cs
+++ b/backend/F1Fantasy/Repository/DriverRepository.cs
@@ -69,6 +69,35 @@ public class DriverRepository
         }
     }
 
+    public async Task<IEnumerable<Driver>> GetActiveDriversAsync(string? season = null)
+    {
+        try
+        {
+            // Use current year if season not specified
+            season ??= DateTime.UtcNow.Year.ToString();
+            
+            // Get drivers that have standings in the current season
+            var activeDriverIds = await _context.DriverStandings
+                .Where(ds => ds.Season == season)
+                .Select(ds => ds.DriverId)
+                .Distinct()
+                .ToListAsync();
+            
+            var activeDrivers = await _context.Drivers
+                .Where(d => activeDriverIds.Contains(d.DriverId))
+                .OrderBy(d => d.FamilyName)
+                .ToListAsync();
+            
+            _logger.LogDebug("Retrieved {Count} active drivers for season {Season}", activeDrivers.Count, season);
+            return activeDrivers;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error retrieving active drivers for season {Season}", season);
+            throw;
+        }
+    }
+
     public async Task ClearAsync()
     {
         try

--- a/backend/F1Fantasy/Services/PredictionService.cs
+++ b/backend/F1Fantasy/Services/PredictionService.cs
@@ -58,13 +58,13 @@ public class PredictionService
             ValidationExtensions.ValidateId(id, "Constructor ID");
         }
 
-        // Validate: Must have all constructors, no duplicates
-        var allConstructors = await _constructorRepository.GetAllAsync();
-        var constructorIds = allConstructors.Select(c => c.ConstructorId).ToList();
+        // Validate: Must have all active constructors for current season, no duplicates
+        var activeConstructors = await _constructorRepository.GetActiveConstructorsAsync();
+        var constructorIds = activeConstructors.Select(c => c.ConstructorId).ToList();
 
         if (rankedConstructorIds.Count != constructorIds.Count)
         {
-            throw new ArgumentException($"Must rank all {constructorIds.Count} constructors");
+            throw new ArgumentException($"Must rank all {constructorIds.Count} active constructors");
         }
 
         if (rankedConstructorIds.Distinct().Count() != rankedConstructorIds.Count)
@@ -108,13 +108,14 @@ public class PredictionService
             ValidationExtensions.ValidateId(id, "Driver ID");
         }
 
-        // Validate: Must have all active drivers (20-22), no duplicates
-        var allDrivers = await _driverRepository.GetAllAsync();
-        var driverIds = allDrivers.Select(d => d.DriverId).ToList();
+        // Validate: Must have all active drivers (typically 20), no duplicates
+        var activeDrivers = await _driverRepository.GetActiveDriversAsync();
+        var driverIds = activeDrivers.Select(d => d.DriverId).ToList();
+        var expectedCount = driverIds.Count;
 
-        if (rankedDriverIds.Count < 20 || rankedDriverIds.Count > 22)
+        if (rankedDriverIds.Count != expectedCount)
         {
-            throw new ArgumentException($"Must rank between 20-22 drivers (found {rankedDriverIds.Count})");
+            throw new ArgumentException($"Must rank all {expectedCount} active drivers (found {rankedDriverIds.Count})");
         }
 
         if (rankedDriverIds.Distinct().Count() != rankedDriverIds.Count)
@@ -154,17 +155,17 @@ public class PredictionService
             throw new ArgumentException("Cannot select the same driver twice");
         }
 
-        var allDrivers = await _driverRepository.GetAllAsync();
-        var driverIds = allDrivers.Select(d => d.DriverId).ToList();
+        var activeDrivers = await _driverRepository.GetActiveDriversAsync();
+        var driverIds = activeDrivers.Select(d => d.DriverId).ToList();
 
         if (driver1Id != null && !driverIds.Contains(driver1Id))
         {
-            throw new ArgumentException("Invalid driver1 ID");
+            throw new ArgumentException("Invalid driver1 ID - driver not active in current season");
         }
 
         if (driver2Id != null && !driverIds.Contains(driver2Id))
         {
-            throw new ArgumentException("Invalid driver2 ID");
+            throw new ArgumentException("Invalid driver2 ID - driver not active in current season");
         }
 
         var prediction = new DriverDraftPrediction
@@ -194,17 +195,17 @@ public class PredictionService
             throw new ArgumentException("Cannot select the same driver twice");
         }
 
-        var allDrivers = await _driverRepository.GetAllAsync();
-        var driverIds = allDrivers.Select(d => d.DriverId).ToList();
+        var activeDrivers = await _driverRepository.GetActiveDriversAsync();
+        var driverIds = activeDrivers.Select(d => d.DriverId).ToList();
 
         if (driver1Id != null && !driverIds.Contains(driver1Id))
         {
-            throw new ArgumentException("Invalid driver1 ID");
+            throw new ArgumentException("Invalid driver1 ID - driver not active in current season");
         }
 
         if (driver2Id != null && !driverIds.Contains(driver2Id))
         {
-            throw new ArgumentException("Invalid driver2 ID");
+            throw new ArgumentException("Invalid driver2 ID - driver not active in current season");
         }
 
         var prediction = new DestructorPrediction
@@ -234,17 +235,17 @@ public class PredictionService
             throw new ArgumentException("Cannot select the same driver twice");
         }
 
-        var allDrivers = await _driverRepository.GetAllAsync();
-        var driverIds = allDrivers.Select(d => d.DriverId).ToList();
+        var activeDrivers = await _driverRepository.GetActiveDriversAsync();
+        var driverIds = activeDrivers.Select(d => d.DriverId).ToList();
 
         if (driver1Id != null && !driverIds.Contains(driver1Id))
         {
-            throw new ArgumentException("Invalid driver1 ID");
+            throw new ArgumentException("Invalid driver1 ID - driver not active in current season");
         }
 
         if (driver2Id != null && !driverIds.Contains(driver2Id))
         {
-            throw new ArgumentException("Invalid driver2 ID");
+            throw new ArgumentException("Invalid driver2 ID - driver not active in current season");
         }
 
         var prediction = new MrSaturdayPrediction
@@ -275,15 +276,15 @@ public class PredictionService
             throw new ArgumentException("Cannot select the same driver multiple times");
         }
 
-        // Validate all driver IDs exist
-        var allDrivers = await _driverRepository.GetAllAsync();
-        var validDriverIds = allDrivers.Select(d => d.DriverId).ToList();
+        // Validate all driver IDs exist and are active in current season
+        var activeDrivers = await _driverRepository.GetActiveDriversAsync();
+        var validDriverIds = activeDrivers.Select(d => d.DriverId).ToList();
 
         foreach (var driverId in driverIds)
         {
             if (!validDriverIds.Contains(driverId))
             {
-                throw new ArgumentException($"Invalid driver ID: {driverId}");
+                throw new ArgumentException($"Invalid driver ID: {driverId} - driver not active in current season");
             }
         }
 


### PR DESCRIPTION
…only

Changed prediction validation to check against drivers and constructors active in the current season (based on standings data) instead of all historical participants in the database.

Key changes:
- Added GetActiveConstructorsAsync() to ConstructorRepository
- Added GetActiveDriversAsync() to DriverRepository
- Both methods query standings tables filtered by current year (DateTime.UtcNow.Year)
- Updated all prediction validations to use active participants only
- Constructor Championship now requires exact count of active constructors
- Driver Championship now requires exact count of active drivers (typically 20)
- Updated error messages to clarify 'not active in current season'

This fixes the issue where users were asked to rank all 214 historical constructors instead of just the ~10 teams in the current season.