### PR TITLE
feat: add Clerk integration for group member display names

### DIFF
--- a/backend/API_TESTING_GUIDE.md
+++ b/backend/API_TESTING_GUIDE.md
@@ -28,9 +28,22 @@ Response:
   "lockMode": "admin",
   "adminUserId": "user_xxx",
   "predictionsLocked": false,
-  "createdAt": "2025-02-22T14:00:00Z"
+  "lockedAt": null,
+  "createdAt": "2025-02-22T14:00:00Z",
+  "members": [
+    {
+      "id": 1,
+      "groupId": 1,
+      "userId": "user_xxx",
+      "displayName": "John Doe",
+      "isAdmin": true,
+      "joinedAt": "2025-02-22T14:00:00Z"
+    }
+  ]
 }
 ```
+
+**Note**: `displayName` is fetched from Clerk (name or username fallback). Admin is auto-added as first member.
 
 ### 2. Get My Groups
 ```http
@@ -38,7 +51,40 @@ GET /api/groups
 Authorization: Bearer YOUR_TOKEN
 ```
 
-Response: Array of groups you're a member of
+Response: Array of groups you're a member of, with enriched member data
+
+```json
+[
+  {
+    "id": 1,
+    "name": "My F1 Fantasy League",
+    "inviteCode": "ABC12XYZ",
+    "lockMode": "admin",
+    "adminUserId": "user_xxx",
+    "predictionsLocked": false,
+    "lockedAt": null,
+    "createdAt": "2025-02-22T14:00:00Z",
+    "members": [
+      {
+        "id": 1,
+        "groupId": 1,
+        "userId": "user_xxx",
+        "displayName": "John Doe",
+        "isAdmin": true,
+        "joinedAt": "2025-02-22T14:00:00Z"
+      },
+      {
+        "id": 2,
+        "groupId": 1,
+        "userId": "user_yyy",
+        "displayName": "Jane Smith",
+        "isAdmin": false,
+        "joinedAt": "2025-02-22T15:30:00Z"
+      }
+    ]
+  }
+]
+```
 
 ### 3. Get Specific Group by ID
 ```http
@@ -46,13 +92,15 @@ GET /api/groups/1
 Authorization: Bearer YOUR_TOKEN
 ```
 
+Response: Group details with all members and their display names from Clerk
+
 ### 4. Get Group by Invite Code
 ```http
 GET /api/groups/invite/ABC12XYZ
 Authorization: Bearer YOUR_TOKEN
 ```
 
-Response: Group details (useful for preview before joining)
+Response: Group details with members and display names (useful for preview before joining)
 
 ### 5. Join a Group
 ```http
@@ -556,6 +604,42 @@ Response:
 - **Constructor Championship**: 10 points exact match, -2 per position delta for ALL constructors
 - **Zero Pointers**: +100 per correct prediction (driver has 0 points), -20 per incorrect (driver has points)
 - **Wildcard**: 100-200 points (admin sets amount and marks fulfilled)
+
+## Response Formats
+
+### Group Response (GroupDto)
+
+All GET endpoints for groups return enriched `GroupDto` objects with member display names fetched from Clerk:
+
+```json
+{
+  "id": 1,
+  "name": "My F1 Fantasy League",
+  "inviteCode": "ABC12XYZ",
+  "lockMode": "admin",
+  "adminUserId": "user_xxx",
+  "createdAt": "2025-02-22T14:00:00Z",
+  "predictionsLocked": false,
+  "lockedAt": null,
+  "members": [
+    {
+      "id": 1,
+      "groupId": 1,
+      "userId": "user_xxx",
+      "displayName": "John Doe",
+      "isAdmin": true,
+      "joinedAt": "2025-02-22T14:00:00Z"
+    }
+  ]
+}
+```
+
+**Member Fields:**
+- `displayName`: First name + last name from Clerk, falls back to username, then user ID
+- `isAdmin`: Boolean indicating if this member is the group admin
+- All other fields are standard group/member data
+
+**Performance Note:** Display names are fetched in parallel from Clerk API for efficiency. Falls back gracefully to user IDs if Clerk API is unavailable.
 
 ## Request Formats
 

--- a/backend/F1Fantasy/Controllers/GroupsController.cs
+++ b/backend/F1Fantasy/Controllers/GroupsController.cs
@@ -1,3 +1,4 @@
+using F1Fantasy.Models;
 using F1Fantasy.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -14,10 +15,12 @@ namespace F1Fantasy.Controllers;
 public class GroupsController : ControllerBase
 {
     private readonly GroupService _groupService;
+    private readonly ClerkService _clerkService;
 
-    public GroupsController(GroupService groupService)
+    public GroupsController(GroupService groupService, ClerkService clerkService)
     {
         _groupService = groupService;
+        _clerkService = clerkService;
     }
 
     private string GetUserId()
@@ -49,7 +52,8 @@ public class GroupsController : ControllerBase
         {
             var userId = GetUserId();
             var groups = await _groupService.GetUserGroupsAsync(userId);
-            return Ok(groups);
+            var groupDtos = await EnrichGroupsWithMemberNamesAsync(groups);
+            return Ok(groupDtos);
         }
         catch (Exception ex)
         {
@@ -64,7 +68,8 @@ public class GroupsController : ControllerBase
         {
             var group = await _groupService.GetGroupByIdAsync(id);
             if (group == null) return NotFound();
-            return Ok(group);
+            var groupDto = await EnrichGroupWithMemberNamesAsync(group);
+            return Ok(groupDto);
         }
         catch (Exception ex)
         {
@@ -79,7 +84,8 @@ public class GroupsController : ControllerBase
         {
             var group = await _groupService.GetGroupByInviteCodeAsync(inviteCode);
             if (group == null) return NotFound();
-            return Ok(group);
+            var groupDto = await EnrichGroupWithMemberNamesAsync(group);
+            return Ok(groupDto);
         }
         catch (Exception ex)
         {
@@ -239,6 +245,60 @@ public class GroupsController : ControllerBase
         {
             return BadRequest(new { error = ex.Message });
         }
+    }
+
+    private async Task<GroupDto> EnrichGroupWithMemberNamesAsync(Group group)
+    {
+        var userIds = group.Members.Select(m => m.UserId).ToList();
+        var displayNames = await _clerkService.GetUserDisplayNamesAsync(userIds);
+
+        return new GroupDto
+        {
+            Id = group.Id,
+            Name = group.Name,
+            InviteCode = group.InviteCode,
+            LockMode = group.LockMode,
+            AdminUserId = group.AdminUserId,
+            CreatedAt = group.CreatedAt,
+            PredictionsLocked = group.PredictionsLocked,
+            LockedAt = group.LockedAt,
+            Members = group.Members.Select(m => new GroupMemberDto
+            {
+                Id = m.Id,
+                GroupId = m.GroupId,
+                UserId = m.UserId,
+                DisplayName = displayNames.GetValueOrDefault(m.UserId, m.UserId),
+                IsAdmin = m.UserId == group.AdminUserId,
+                JoinedAt = m.JoinedAt
+            }).ToList()
+        };
+    }
+
+    private async Task<List<GroupDto>> EnrichGroupsWithMemberNamesAsync(List<Group> groups)
+    {
+        var allUserIds = groups.SelectMany(g => g.Members.Select(m => m.UserId)).Distinct().ToList();
+        var displayNames = await _clerkService.GetUserDisplayNamesAsync(allUserIds);
+
+        return groups.Select(group => new GroupDto
+        {
+            Id = group.Id,
+            Name = group.Name,
+            InviteCode = group.InviteCode,
+            LockMode = group.LockMode,
+            AdminUserId = group.AdminUserId,
+            CreatedAt = group.CreatedAt,
+            PredictionsLocked = group.PredictionsLocked,
+            LockedAt = group.LockedAt,
+            Members = group.Members.Select(m => new GroupMemberDto
+            {
+                Id = m.Id,
+                GroupId = m.GroupId,
+                UserId = m.UserId,
+                DisplayName = displayNames.GetValueOrDefault(m.UserId, m.UserId),
+                IsAdmin = m.UserId == group.AdminUserId,
+                JoinedAt = m.JoinedAt
+            }).ToList()
+        }).ToList();
     }
 }
 

--- a/backend/F1Fantasy/Models/GroupDto.cs
+++ b/backend/F1Fantasy/Models/GroupDto.cs
@@ -1,0 +1,24 @@
+namespace F1Fantasy.Models;
+
+public class GroupDto
+{
+    public int Id { get; set; }
+    public required string Name { get; set; }
+    public required string InviteCode { get; set; }
+    public required string LockMode { get; set; }
+    public required string AdminUserId { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public bool PredictionsLocked { get; set; }
+    public DateTime? LockedAt { get; set; }
+    public List<GroupMemberDto> Members { get; set; } = new();
+}
+
+public class GroupMemberDto
+{
+    public int Id { get; set; }
+    public int GroupId { get; set; }
+    public required string UserId { get; set; }
+    public required string DisplayName { get; set; } // Name from Clerk (fallback to username)
+    public bool IsAdmin { get; set; }
+    public DateTime JoinedAt { get; set; }
+}

--- a/backend/F1Fantasy/Program.cs
+++ b/backend/F1Fantasy/Program.cs
@@ -135,6 +135,7 @@ builder.Services.AddScoped<F1Fantasy.Services.GroupService>();
 builder.Services.AddScoped<F1Fantasy.Services.PredictionService>();
 builder.Services.AddScoped<F1Fantasy.Services.ScoringService>();
 builder.Services.AddScoped<F1Fantasy.Services.StandingsService>();
+builder.Services.AddScoped<F1Fantasy.Services.ClerkService>();
 
 // Rate limiting and security services
 builder.Services.AddSingleton<IIpBlacklistService, IpBlacklistService>();

--- a/backend/F1Fantasy/Services/ClerkService.cs
+++ b/backend/F1Fantasy/Services/ClerkService.cs
@@ -1,0 +1,91 @@
+using Clerk.BackendAPI;
+using Clerk.BackendAPI.Models.Operations;
+
+namespace F1Fantasy.Services;
+
+public class ClerkService
+{
+    private readonly ClerkBackendApi _clerkClient;
+    private readonly ILogger<ClerkService> _logger;
+
+    public ClerkService(ILogger<ClerkService> logger)
+    {
+        _logger = logger;
+        var clerkSecretKey = Environment.GetEnvironmentVariable("CLERK_SECRET_KEY");
+        
+        if (string.IsNullOrEmpty(clerkSecretKey))
+        {
+            throw new InvalidOperationException("CLERK_SECRET_KEY environment variable is not set.");
+        }
+
+        _clerkClient = new ClerkBackendApi(clerkSecretKey);
+    }
+
+    /// <summary>
+    /// Fetches user display name from Clerk. Returns first name + last name if available, otherwise username.
+    /// Falls back to the user ID if all else fails.
+    /// </summary>
+    public async Task<string> GetUserDisplayNameAsync(string userId)
+    {
+        try
+        {
+            var response = await _clerkClient.Users.GetAsync(userId);
+            
+            if (response?.User == null)
+            {
+                _logger.LogWarning("User {UserId} not found in Clerk", userId);
+                return userId; // Fallback to user ID
+            }
+
+            var user = response.User;
+
+            // Try to build full name from first and last name
+            var firstName = user.FirstName?.Trim();
+            var lastName = user.LastName?.Trim();
+
+            if (!string.IsNullOrEmpty(firstName) && !string.IsNullOrEmpty(lastName))
+            {
+                return $"{firstName} {lastName}";
+            }
+            else if (!string.IsNullOrEmpty(firstName))
+            {
+                return firstName;
+            }
+            else if (!string.IsNullOrEmpty(lastName))
+            {
+                return lastName;
+            }
+
+            // Fallback to username
+            if (!string.IsNullOrEmpty(user.Username))
+            {
+                return user.Username;
+            }
+
+            // Last resort - use the user ID
+            _logger.LogWarning("No name or username found for user {UserId}, using ID as display name", userId);
+            return userId;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error fetching user {UserId} from Clerk", userId);
+            return userId; // Fallback to user ID on error
+        }
+    }
+
+    /// <summary>
+    /// Fetches multiple user display names in parallel for efficiency
+    /// </summary>
+    public async Task<Dictionary<string, string>> GetUserDisplayNamesAsync(IEnumerable<string> userIds)
+    {
+        var uniqueUserIds = userIds.Distinct().ToList();
+        var tasks = uniqueUserIds.Select(async userId => new
+        {
+            UserId = userId,
+            DisplayName = await GetUserDisplayNameAsync(userId)
+        });
+
+        var results = await Task.WhenAll(tasks);
+        return results.ToDictionary(r => r.UserId, r => r.DisplayName);
+    }
+}


### PR DESCRIPTION
- Created GroupDto and GroupMemberDto models for enriched responses
- Implemented ClerkService to fetch user names from Clerk API
- Updated all GET group endpoints to return display names
- Display names fallback: first+last name → username → user ID
- Parallel fetching for efficiency with graceful error handling
- Updated API documentation with new response format

Closes #29