### PR TITLE
fix: auto-populate active season data for drivers and constructors

### DIFF
--- a/backend/F1Fantasy/Services/ConstructorService.cs
+++ b/backend/F1Fantasy/Services/ConstructorService.cs
@@ -202,4 +202,43 @@ public class ConstructorService
         _logger.LogInformation("Retrieved {Count} cached constructors", constructors.Count());
         return constructors;
     }
+
+    public async Task<IEnumerable<Constructor>> GetActiveConstructorsAsync(string? season = null)
+    {
+        // Use current year if season not specified
+        season ??= DateTime.UtcNow.Year.ToString();
+        
+        _logger.LogDebug("Getting active constructors for season {Season}", season);
+        
+        // Check if we have any active constructors for this season
+        var activeConstructors = await _constructorRepository.GetActiveConstructorsAsync(season);
+        
+        // If no active constructors found, fetch them from the API
+        if (!activeConstructors.Any())
+        {
+            _logger.LogInformation("No active constructors found for season {Season}. Fetching from API...", season);
+            try
+            {
+                // This will populate the ActiveSeasons list
+                await GetConstructorsBySeasonAsync(season);
+                
+                // Retrieve again after populating
+                activeConstructors = await _constructorRepository.GetActiveConstructorsAsync(season);
+                _logger.LogInformation("Successfully populated {Count} active constructors for season {Season}", 
+                    activeConstructors.Count(), season);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to fetch active constructors for season {Season} from API", season);
+                throw;
+            }
+        }
+        else
+        {
+            _logger.LogDebug("Retrieved {Count} active constructors for season {Season} from cache", 
+                activeConstructors.Count(), season);
+        }
+        
+        return activeConstructors;
+    }
 }

--- a/backend/F1Fantasy/Services/DriverService.cs
+++ b/backend/F1Fantasy/Services/DriverService.cs
@@ -206,4 +206,43 @@ public class DriverService
         _logger.LogInformation("Retrieved {Count} cached drivers", drivers.Count());
         return drivers;
     }
+
+    public async Task<IEnumerable<Driver>> GetActiveDriversAsync(string? season = null)
+    {
+        // Use current year if season not specified
+        season ??= DateTime.UtcNow.Year.ToString();
+        
+        _logger.LogDebug("Getting active drivers for season {Season}", season);
+        
+        // Check if we have any active drivers for this season
+        var activeDrivers = await _driverRepository.GetActiveDriversAsync(season);
+        
+        // If no active drivers found, fetch them from the API
+        if (!activeDrivers.Any())
+        {
+            _logger.LogInformation("No active drivers found for season {Season}. Fetching from API...", season);
+            try
+            {
+                // This will populate the ActiveSeasons list
+                await GetDriversBySeasonAsync(season);
+                
+                // Retrieve again after populating
+                activeDrivers = await _driverRepository.GetActiveDriversAsync(season);
+                _logger.LogInformation("Successfully populated {Count} active drivers for season {Season}", 
+                    activeDrivers.Count(), season);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to fetch active drivers for season {Season} from API", season);
+                throw;
+            }
+        }
+        else
+        {
+            _logger.LogDebug("Retrieved {Count} active drivers for season {Season} from cache", 
+                activeDrivers.Count(), season);
+        }
+        
+        return activeDrivers;
+    }
 }

--- a/backend/F1Fantasy/Services/PredictionService.cs
+++ b/backend/F1Fantasy/Services/PredictionService.cs
@@ -8,19 +8,19 @@ public class PredictionService
 {
     private readonly PredictionRepository _predictionRepository;
     private readonly GroupRepository _groupRepository;
-    private readonly ConstructorRepository _constructorRepository;
-    private readonly DriverRepository _driverRepository;
+    private readonly ConstructorService _constructorService;
+    private readonly DriverService _driverService;
 
     public PredictionService(
         PredictionRepository predictionRepository,
         GroupRepository groupRepository,
-        ConstructorRepository constructorRepository,
-        DriverRepository driverRepository)
+        ConstructorService constructorService,
+        DriverService driverService)
     {
         _predictionRepository = predictionRepository;
         _groupRepository = groupRepository;
-        _constructorRepository = constructorRepository;
-        _driverRepository = driverRepository;
+        _constructorService = constructorService;
+        _driverService = driverService;
     }
 
     private async Task ValidateGroupAndLockAsync(int groupId, string userId)
@@ -59,7 +59,7 @@ public class PredictionService
         }
 
         // Validate: Must have all active constructors for current season, no duplicates
-        var activeConstructors = await _constructorRepository.GetActiveConstructorsAsync();
+        var activeConstructors = await _constructorService.GetActiveConstructorsAsync();
         var constructorIds = activeConstructors.Select(c => c.ConstructorId).ToList();
 
         if (rankedConstructorIds.Count != constructorIds.Count)
@@ -109,7 +109,7 @@ public class PredictionService
         }
 
         // Validate: Must have all active drivers (typically 20), no duplicates
-        var activeDrivers = await _driverRepository.GetActiveDriversAsync();
+        var activeDrivers = await _driverService.GetActiveDriversAsync();
         var driverIds = activeDrivers.Select(d => d.DriverId).ToList();
         var expectedCount = driverIds.Count;
 
@@ -155,7 +155,7 @@ public class PredictionService
             throw new ArgumentException("Cannot select the same driver twice");
         }
 
-        var activeDrivers = await _driverRepository.GetActiveDriversAsync();
+        var activeDrivers = await _driverService.GetActiveDriversAsync();
         var driverIds = activeDrivers.Select(d => d.DriverId).ToList();
 
         if (driver1Id != null && !driverIds.Contains(driver1Id))
@@ -195,7 +195,7 @@ public class PredictionService
             throw new ArgumentException("Cannot select the same driver twice");
         }
 
-        var activeDrivers = await _driverRepository.GetActiveDriversAsync();
+        var activeDrivers = await _driverService.GetActiveDriversAsync();
         var driverIds = activeDrivers.Select(d => d.DriverId).ToList();
 
         if (driver1Id != null && !driverIds.Contains(driver1Id))
@@ -235,7 +235,7 @@ public class PredictionService
             throw new ArgumentException("Cannot select the same driver twice");
         }
 
-        var activeDrivers = await _driverRepository.GetActiveDriversAsync();
+        var activeDrivers = await _driverService.GetActiveDriversAsync();
         var driverIds = activeDrivers.Select(d => d.DriverId).ToList();
 
         if (driver1Id != null && !driverIds.Contains(driver1Id))
@@ -277,7 +277,7 @@ public class PredictionService
         }
 
         // Validate all driver IDs exist and are active in current season
-        var activeDrivers = await _driverRepository.GetActiveDriversAsync();
+        var activeDrivers = await _driverService.GetActiveDriversAsync();
         var validDriverIds = activeDrivers.Select(d => d.DriverId).ToList();
 
         foreach (var driverId in driverIds)


### PR DESCRIPTION
Add automatic population of active season data when fetching active drivers/constructors. Previously, active drivers/constructors would only be populated if explicitly called via the admin endpoint. Now, when predictions are validated, the system automatically fetches and caches the current season's data from the API if not already available.

- Add GetActiveDriversAsync() to DriverService with auto-population
- Add GetActiveConstructorsAsync() to ConstructorService with auto-population
- Update PredictionService to use service layer instead of repositories directly
- Ensures predictions work based on current calendar year without manual population

Closes #32
Closes #31
Closes #30