### PR TITLE
fix: add endpoint for viewing all wildcard predictions in group

### DIFF
--- a/backend/API_TESTING_GUIDE.md
+++ b/backend/API_TESTING_GUIDE.md
@@ -297,6 +297,14 @@ GET /api/predictions/groups/1/wildcard
 Authorization: Bearer YOUR_TOKEN
 ```
 
+### 9b. Get All Wildcard Predictions in Group
+```http
+GET /api/predictions/groups/1/wildcards
+Authorization: Bearer YOUR_TOKEN
+```
+
+**Note**: Returns all wildcard predictions for all members in the group. Useful for seeing what other people predicted.
+
 ### 10. Lock Predictions (Admin Only)
 ```http
 POST /api/groups/1/lock
@@ -518,6 +526,7 @@ All prediction endpoints require authentication. Replace `{groupId}` with the gr
 |--------|----------|-------------|
 | POST | `/api/predictions/groups/{groupId}/wildcard` | Submit wildcard statement |
 | GET | `/api/predictions/groups/{groupId}/wildcard` | Get your wildcard prediction |
+| GET | `/api/predictions/groups/{groupId}/wildcards` | Get all wildcard predictions in the group |
 
 ### Standings Endpoints
 

--- a/backend/F1Fantasy/Controllers/PredictionsController.cs
+++ b/backend/F1Fantasy/Controllers/PredictionsController.cs
@@ -283,6 +283,21 @@ public class PredictionsController : ControllerBase
             return BadRequest(new { error = ex.Message });
         }
     }
+
+    [HttpGet("groups/{groupId}/wildcards")]
+    public async Task<IActionResult> GetAllWildcards(int groupId)
+    {
+        try
+        {
+            var userId = GetUserId();
+            var predictions = await _predictionService.GetAllWildcardsAsync(groupId, userId);
+            return Ok(predictions);
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
 }
 
 public record DriverDraftRequest(string? Driver1Id, string? Driver2Id);

--- a/backend/F1Fantasy/Services/PredictionService.cs
+++ b/backend/F1Fantasy/Services/PredictionService.cs
@@ -328,4 +328,15 @@ public class PredictionService
     {
         return await _predictionRepository.GetWildcardAsync(groupId, userId);
     }
+
+    public async Task<List<WildcardPrediction>> GetAllWildcardsAsync(int groupId, string userId)
+    {
+        // Verify user is a member of the group
+        if (!await _groupRepository.IsUserMemberAsync(groupId, userId))
+        {
+            throw new UnauthorizedAccessException("User is not a member of this group");
+        }
+
+        return await _predictionRepository.GetAllWildcardsAsync(groupId);
+    }
 }


### PR DESCRIPTION
Closes #33

- Added GET /api/predictions/groups/{groupId}/wildcards endpoint
- Allows all group members to view wildcard predictions from other members
- Added GetAllWildcardsAsync method to PredictionService with group membership validation
- Updated API_TESTING_GUIDE.md with new endpoint documentation