### PR TITLE
fix: properly persist ActiveSeasons when updating drivers and constru…

### DIFF
--- a/backend/F1Fantasy/Repository/ConstructorRepository.cs
+++ b/backend/F1Fantasy/Repository/ConstructorRepository.cs
@@ -19,7 +19,19 @@ public class ConstructorRepository
         
         if (existing != null)
         {
-            _context.Entry(existing).CurrentValues.SetValues(constructor);
+            // Update primitive properties
+            existing.Name = constructor.Name;
+            existing.Url = constructor.Url;
+            existing.Nationality = constructor.Nationality;
+            
+            // Merge ActiveSeasons - add any new seasons that aren't already present
+            foreach (var season in constructor.ActiveSeasons)
+            {
+                if (!existing.ActiveSeasons.Contains(season))
+                {
+                    existing.ActiveSeasons.Add(season);
+                }
+            }
         }
         else
         {

--- a/backend/F1Fantasy/Repository/DriverRepository.cs
+++ b/backend/F1Fantasy/Repository/DriverRepository.cs
@@ -24,7 +24,24 @@ public class DriverRepository
             if (existing != null)
             {
                 _logger.LogDebug("Updating existing driver: {DriverId}", driver.DriverId);
-                _context.Entry(existing).CurrentValues.SetValues(driver);
+                
+                // Update primitive properties
+                existing.PermanentNumber = driver.PermanentNumber;
+                existing.Code = driver.Code;
+                existing.GivenName = driver.GivenName;
+                existing.FamilyName = driver.FamilyName;
+                existing.DateOfBirth = driver.DateOfBirth;
+                existing.Nationality = driver.Nationality;
+                existing.Url = driver.Url;
+                
+                // Merge ActiveSeasons - add any new seasons that aren't already present
+                foreach (var season in driver.ActiveSeasons)
+                {
+                    if (!existing.ActiveSeasons.Contains(season))
+                    {
+                        existing.ActiveSeasons.Add(season);
+                    }
+                }
             }
             else
             {


### PR DESCRIPTION
…ctors

Replace SetValues() with manual property updates to correctly handle the ActiveSeasons list collection. SetValues() doesn't properly merge list properties, causing season data to be lost during updates.

This fixes the issue where constructors/drivers were fetched from the API but showed 0 active entries for the current season.