### PR TITLE
fix: correct Include/Select order in GetGroupsByUserIdAsync

### DIFF
--- a/backend/F1Fantasy/Repository/GroupRepository.cs
+++ b/backend/F1Fantasy/Repository/GroupRepository.cs
@@ -42,8 +42,9 @@ public class GroupRepository
         // AsSplitQuery prevents cartesian explosion with multiple members
         return await _context.GroupMembers
             .Where(gm => gm.UserId == userId)
+            .Include(gm => gm.Group)
+                .ThenInclude(g => g.Members)
             .Select(gm => gm.Group)
-            .Include(g => g.Members)
             .AsSplitQuery()
             .Distinct()
             .ToListAsync();


### PR DESCRIPTION
Move Include operation before Select to fix EF Core query error. Include must be applied to the base queryable before projection.