### PR TITLE
Add comprehensive performance logging and improve prediction validation

### DIFF
--- a/backend/F1Fantasy/Controllers/GroupsController.cs
+++ b/backend/F1Fantasy/Controllers/GroupsController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
 using System.Security.Claims;
 
 namespace F1Fantasy.Controllers;
@@ -16,11 +17,13 @@ public class GroupsController : ControllerBase
 {
     private readonly GroupService _groupService;
     private readonly ClerkService _clerkService;
+    private readonly ILogger<GroupsController> _logger;
 
-    public GroupsController(GroupService groupService, ClerkService clerkService)
+    public GroupsController(GroupService groupService, ClerkService clerkService, ILogger<GroupsController> logger)
     {
         _groupService = groupService;
         _clerkService = clerkService;
+        _logger = logger;
     }
 
     private string GetUserId()
@@ -48,15 +51,26 @@ public class GroupsController : ControllerBase
     [HttpGet]
     public async Task<IActionResult> GetMyGroups()
     {
+        var stopwatch = Stopwatch.StartNew();
         try
         {
             var userId = GetUserId();
+            _logger.LogInformation("[GetMyGroups] Start - UserId: {UserId} - Elapsed: {Elapsed}ms", userId, stopwatch.ElapsedMilliseconds);
+            
             var groups = await _groupService.GetUserGroupsAsync(userId);
+            _logger.LogInformation("[GetMyGroups] After GetUserGroupsAsync - GroupCount: {Count} - Elapsed: {Elapsed}ms", groups.Count, stopwatch.ElapsedMilliseconds);
+            
             var groupDtos = await EnrichGroupsWithMemberNamesAsync(groups);
+            _logger.LogInformation("[GetMyGroups] After EnrichGroupsWithMemberNamesAsync - Elapsed: {Elapsed}ms", stopwatch.ElapsedMilliseconds);
+            
+            stopwatch.Stop();
+            _logger.LogInformation("[GetMyGroups] Complete - Total: {Total}ms", stopwatch.ElapsedMilliseconds);
             return Ok(groupDtos);
         }
         catch (Exception ex)
         {
+            stopwatch.Stop();
+            _logger.LogError(ex, "[GetMyGroups] Error after {Elapsed}ms: {Message}", stopwatch.ElapsedMilliseconds, ex.Message);
             return BadRequest(new { error = ex.Message });
         }
     }
@@ -276,10 +290,14 @@ public class GroupsController : ControllerBase
 
     private async Task<List<GroupDto>> EnrichGroupsWithMemberNamesAsync(List<Group> groups)
     {
+        var enrichStopwatch = Stopwatch.StartNew();
         var allUserIds = groups.SelectMany(g => g.Members.Select(m => m.UserId)).Distinct().ToList();
+        _logger.LogInformation("[EnrichGroupsWithMemberNamesAsync] Distinct UserIds: {Count}, Elapsed: {Elapsed}ms", allUserIds.Count, enrichStopwatch.ElapsedMilliseconds);
+        
         var displayNames = await _clerkService.GetUserDisplayNamesAsync(allUserIds);
+        _logger.LogInformation("[EnrichGroupsWithMemberNamesAsync] After ClerkService call - DisplayNames: {Count}, Elapsed: {Elapsed}ms", displayNames.Count, enrichStopwatch.ElapsedMilliseconds);
 
-        return groups.Select(group => new GroupDto
+        var result = groups.Select(group => new GroupDto
         {
             Id = group.Id,
             Name = group.Name,
@@ -299,6 +317,10 @@ public class GroupsController : ControllerBase
                 JoinedAt = m.JoinedAt
             }).ToList()
         }).ToList();
+        
+        enrichStopwatch.Stop();
+        _logger.LogInformation("[EnrichGroupsWithMemberNamesAsync] Complete - Total: {Elapsed}ms", enrichStopwatch.ElapsedMilliseconds);
+        return result;
     }
 }
 

--- a/backend/F1Fantasy/Repository/GroupRepository.cs
+++ b/backend/F1Fantasy/Repository/GroupRepository.cs
@@ -1,16 +1,19 @@
 using F1Fantasy.Data;
 using F1Fantasy.Models;
 using Microsoft.EntityFrameworkCore;
+using System.Diagnostics;
 
 namespace F1Fantasy.Repository;
 
 public class GroupRepository
 {
     private readonly F1FantasyDbContext _context;
+    private readonly ILogger<GroupRepository> _logger;
 
-    public GroupRepository(F1FantasyDbContext context)
+    public GroupRepository(F1FantasyDbContext context, ILogger<GroupRepository> logger)
     {
         _context = context;
+        _logger = logger;
     }
 
     public async Task<Group?> GetByIdAsync(int id)
@@ -38,9 +41,12 @@ public class GroupRepository
 
     public async Task<List<Group>> GetGroupsByUserIdAsync(string userId)
     {
+        var stopwatch = Stopwatch.StartNew();
+        _logger.LogInformation("[GroupRepository.GetGroupsByUserIdAsync] Start - UserId: {UserId}", userId);
+        
         // Use more efficient join instead of Where/Any
         // AsSplitQuery prevents cartesian explosion with multiple members
-        return await _context.GroupMembers
+        var result = await _context.GroupMembers
             .Where(gm => gm.UserId == userId)
             .Include(gm => gm.Group)
                 .ThenInclude(g => g.Members)
@@ -48,6 +54,13 @@ public class GroupRepository
             .AsSplitQuery()
             .Distinct()
             .ToListAsync();
+        
+        stopwatch.Stop();
+        _logger.LogInformation("[GroupRepository.GetGroupsByUserIdAsync] Complete - GroupCount: {Count}, MemberCount: {MemberCount}, Elapsed: {Elapsed}ms", 
+            result.Count, 
+            result.Sum(g => g.Members.Count), 
+            stopwatch.ElapsedMilliseconds);
+        return result;
     }
 
     public async Task<Group> CreateAsync(Group group)

--- a/backend/F1Fantasy/Services/ConstructorService.cs
+++ b/backend/F1Fantasy/Services/ConstructorService.cs
@@ -208,34 +208,42 @@ public class ConstructorService
         // Use current year if season not specified
         season ??= DateTime.UtcNow.Year.ToString();
         
-        _logger.LogDebug("Getting active constructors for season {Season}", season);
+        _logger.LogInformation("[GetActiveConstructorsAsync] Getting active constructors for season {Season}", season);
         
         // Check if we have any active constructors for this season
         var activeConstructors = await _constructorRepository.GetActiveConstructorsAsync(season);
+        _logger.LogInformation("[GetActiveConstructorsAsync] Initial query returned {Count} constructors for season {Season}", 
+            activeConstructors.Count(), season);
         
         // If no active constructors found, fetch them from the API
         if (!activeConstructors.Any())
         {
-            _logger.LogInformation("No active constructors found for season {Season}. Fetching from API...", season);
+            _logger.LogWarning("[GetActiveConstructorsAsync] No active constructors found for season {Season}. Attempting to fetch from API...", season);
             try
             {
                 // This will populate the ActiveSeasons list
-                await GetConstructorsBySeasonAsync(season);
+                var fetchedConstructors = await GetConstructorsBySeasonAsync(season);
+                _logger.LogInformation("[GetActiveConstructorsAsync] GetConstructorsBySeasonAsync returned {Count} constructors", fetchedConstructors.Count());
                 
                 // Retrieve again after populating
                 activeConstructors = await _constructorRepository.GetActiveConstructorsAsync(season);
-                _logger.LogInformation("Successfully populated {Count} active constructors for season {Season}", 
+                _logger.LogInformation("[GetActiveConstructorsAsync] Successfully populated {Count} active constructors for season {Season}", 
                     activeConstructors.Count(), season);
+                
+                if (!activeConstructors.Any())
+                {
+                    _logger.LogError("[GetActiveConstructorsAsync] After API fetch, still no active constructors found for season {Season}. This indicates a data population issue.", season);
+                }
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to fetch active constructors for season {Season} from API", season);
+                _logger.LogError(ex, "[GetActiveConstructorsAsync] Failed to fetch active constructors for season {Season} from API: {Message}", season, ex.Message);
                 throw;
             }
         }
         else
         {
-            _logger.LogDebug("Retrieved {Count} active constructors for season {Season} from cache", 
+            _logger.LogInformation("[GetActiveConstructorsAsync] Retrieved {Count} active constructors for season {Season} from database", 
                 activeConstructors.Count(), season);
         }
         

--- a/backend/F1Fantasy/Services/DriverService.cs
+++ b/backend/F1Fantasy/Services/DriverService.cs
@@ -212,34 +212,42 @@ public class DriverService
         // Use current year if season not specified
         season ??= DateTime.UtcNow.Year.ToString();
         
-        _logger.LogDebug("Getting active drivers for season {Season}", season);
+        _logger.LogInformation("[GetActiveDriversAsync] Getting active drivers for season {Season}", season);
         
         // Check if we have any active drivers for this season
         var activeDrivers = await _driverRepository.GetActiveDriversAsync(season);
+        _logger.LogInformation("[GetActiveDriversAsync] Initial query returned {Count} drivers for season {Season}", 
+            activeDrivers.Count(), season);
         
         // If no active drivers found, fetch them from the API
         if (!activeDrivers.Any())
         {
-            _logger.LogInformation("No active drivers found for season {Season}. Fetching from API...", season);
+            _logger.LogWarning("[GetActiveDriversAsync] No active drivers found for season {Season}. Attempting to fetch from API...", season);
             try
             {
                 // This will populate the ActiveSeasons list
-                await GetDriversBySeasonAsync(season);
+                var fetchedDrivers = await GetDriversBySeasonAsync(season);
+                _logger.LogInformation("[GetActiveDriversAsync] GetDriversBySeasonAsync returned {Count} drivers", fetchedDrivers.Count());
                 
                 // Retrieve again after populating
                 activeDrivers = await _driverRepository.GetActiveDriversAsync(season);
-                _logger.LogInformation("Successfully populated {Count} active drivers for season {Season}", 
+                _logger.LogInformation("[GetActiveDriversAsync] Successfully populated {Count} active drivers for season {Season}", 
                     activeDrivers.Count(), season);
+                
+                if (!activeDrivers.Any())
+                {
+                    _logger.LogError("[GetActiveDriversAsync] After API fetch, still no active drivers found for season {Season}. This indicates a data population issue.", season);
+                }
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to fetch active drivers for season {Season} from API", season);
+                _logger.LogError(ex, "[GetActiveDriversAsync] Failed to fetch active drivers for season {Season} from API: {Message}", season, ex.Message);
                 throw;
             }
         }
         else
         {
-            _logger.LogDebug("Retrieved {Count} active drivers for season {Season} from cache", 
+            _logger.LogInformation("[GetActiveDriversAsync] Retrieved {Count} active drivers for season {Season} from database", 
                 activeDrivers.Count(), season);
         }
         

--- a/backend/F1Fantasy/Services/GroupService.cs
+++ b/backend/F1Fantasy/Services/GroupService.cs
@@ -1,16 +1,19 @@
 using F1Fantasy.Models;
 using F1Fantasy.Repository;
 using F1Fantasy.Validation;
+using System.Diagnostics;
 
 namespace F1Fantasy.Services;
 
 public class GroupService
 {
     private readonly GroupRepository _groupRepository;
+    private readonly ILogger<GroupService> _logger;
 
-    public GroupService(GroupRepository groupRepository)
+    public GroupService(GroupRepository groupRepository, ILogger<GroupService> logger)
     {
         _groupRepository = groupRepository;
+        _logger = logger;
     }
 
     public async Task<Group> CreateGroupAsync(string name, string adminUserId, string lockMode)
@@ -56,7 +59,14 @@ public class GroupService
 
     public async Task<List<Group>> GetUserGroupsAsync(string userId)
     {
-        return await _groupRepository.GetGroupsByUserIdAsync(userId);
+        var stopwatch = Stopwatch.StartNew();
+        _logger.LogInformation("[GroupService.GetUserGroupsAsync] Start - UserId: {UserId}", userId);
+        
+        var result = await _groupRepository.GetGroupsByUserIdAsync(userId);
+        
+        stopwatch.Stop();
+        _logger.LogInformation("[GroupService.GetUserGroupsAsync] Complete - GroupCount: {Count}, Elapsed: {Elapsed}ms", result.Count, stopwatch.ElapsedMilliseconds);
+        return result;
     }
 
     public async Task<GroupMember> JoinGroupAsync(int groupId, string userId)

--- a/backend/F1Fantasy/Services/PredictionService.cs
+++ b/backend/F1Fantasy/Services/PredictionService.cs
@@ -1,6 +1,7 @@
 using F1Fantasy.Models;
 using F1Fantasy.Repository;
 using F1Fantasy.Validation;
+using System.Diagnostics;
 
 namespace F1Fantasy.Services;
 
@@ -10,17 +11,20 @@ public class PredictionService
     private readonly GroupRepository _groupRepository;
     private readonly ConstructorService _constructorService;
     private readonly DriverService _driverService;
+    private readonly ILogger<PredictionService> _logger;
 
     public PredictionService(
         PredictionRepository predictionRepository,
         GroupRepository groupRepository,
         ConstructorService constructorService,
-        DriverService driverService)
+        DriverService driverService,
+        ILogger<PredictionService> logger)
     {
         _predictionRepository = predictionRepository;
         _groupRepository = groupRepository;
         _constructorService = constructorService;
         _driverService = driverService;
+        _logger = logger;
     }
 
     private async Task ValidateGroupAndLockAsync(int groupId, string userId)
@@ -46,6 +50,10 @@ public class PredictionService
     public async Task<ConstructorChampionshipPrediction> SaveConstructorChampionshipAsync(
         int groupId, string userId, List<string> rankedConstructorIds)
     {
+        var stopwatch = Stopwatch.StartNew();
+        _logger.LogInformation("[SaveConstructorChampionshipAsync] Start - GroupId: {GroupId}, UserId: {UserId}, ProvidedCount: {Count}", 
+            groupId, userId, rankedConstructorIds.Count);
+        
         await ValidateGroupAndLockAsync(groupId, userId);
 
         // Validate list size to prevent DoS attacks
@@ -58,13 +66,21 @@ public class PredictionService
             ValidationExtensions.ValidateId(id, "Constructor ID");
         }
 
+        _logger.LogInformation("[SaveConstructorChampionshipAsync] Fetching active constructors - Elapsed: {Elapsed}ms", 
+            stopwatch.ElapsedMilliseconds);
+        
         // Validate: Must have all active constructors for current season, no duplicates
         var activeConstructors = await _constructorService.GetActiveConstructorsAsync();
         var constructorIds = activeConstructors.Select(c => c.ConstructorId).ToList();
+        
+        _logger.LogInformation("[SaveConstructorChampionshipAsync] Active constructors retrieved - Count: {Count}, IDs: [{IDs}], Elapsed: {Elapsed}ms", 
+            constructorIds.Count, string.Join(", ", constructorIds), stopwatch.ElapsedMilliseconds);
 
         if (rankedConstructorIds.Count != constructorIds.Count)
         {
-            throw new ArgumentException($"Must rank all {constructorIds.Count} active constructors");
+            var errorMsg = $"Must rank all {constructorIds.Count} active constructors (you provided {rankedConstructorIds.Count}). Expected season: {DateTime.UtcNow.Year}";
+            _logger.LogWarning("[SaveConstructorChampionshipAsync] Validation failed: {Error}", errorMsg);
+            throw new ArgumentException(errorMsg);
         }
 
         if (rankedConstructorIds.Distinct().Count() != rankedConstructorIds.Count)
@@ -74,7 +90,10 @@ public class PredictionService
 
         if (rankedConstructorIds.Any(id => !constructorIds.Contains(id)))
         {
-            throw new ArgumentException("Invalid constructor IDs detected");
+            var invalidIds = rankedConstructorIds.Where(id => !constructorIds.Contains(id)).ToList();
+            var errorMsg = $"Invalid constructor IDs detected: [{string.Join(", ", invalidIds)}]";
+            _logger.LogWarning("[SaveConstructorChampionshipAsync] {Error}", errorMsg);
+            throw new ArgumentException(errorMsg);
         }
 
         var prediction = new ConstructorChampionshipPrediction
@@ -84,7 +103,10 @@ public class PredictionService
             RankedConstructorIds = rankedConstructorIds
         };
 
-        return await _predictionRepository.UpsertConstructorChampionshipAsync(prediction);
+        var result = await _predictionRepository.UpsertConstructorChampionshipAsync(prediction);
+        stopwatch.Stop();
+        _logger.LogInformation("[SaveConstructorChampionshipAsync] Complete - Total: {Elapsed}ms", stopwatch.ElapsedMilliseconds);
+        return result;
     }
 
     public async Task<ConstructorChampionshipPrediction?> GetConstructorChampionshipAsync(int groupId, string userId)
@@ -96,6 +118,10 @@ public class PredictionService
     public async Task<DriverChampionshipPrediction> SaveDriverChampionshipAsync(
         int groupId, string userId, List<string> rankedDriverIds)
     {
+        var stopwatch = Stopwatch.StartNew();
+        _logger.LogInformation("[SaveDriverChampionshipAsync] Start - GroupId: {GroupId}, UserId: {UserId}, ProvidedCount: {Count}", 
+            groupId, userId, rankedDriverIds.Count);
+        
         await ValidateGroupAndLockAsync(groupId, userId);
 
         // Validate list size to prevent DoS attacks
@@ -108,14 +134,22 @@ public class PredictionService
             ValidationExtensions.ValidateId(id, "Driver ID");
         }
 
+        _logger.LogInformation("[SaveDriverChampionshipAsync] Fetching active drivers - Elapsed: {Elapsed}ms", 
+            stopwatch.ElapsedMilliseconds);
+        
         // Validate: Must have all active drivers (typically 20), no duplicates
         var activeDrivers = await _driverService.GetActiveDriversAsync();
         var driverIds = activeDrivers.Select(d => d.DriverId).ToList();
         var expectedCount = driverIds.Count;
+        
+        _logger.LogInformation("[SaveDriverChampionshipAsync] Active drivers retrieved - Count: {Count}, IDs: [{IDs}], Elapsed: {Elapsed}ms", 
+            expectedCount, string.Join(", ", driverIds.Take(5)) + (driverIds.Count > 5 ? "..." : ""), stopwatch.ElapsedMilliseconds);
 
         if (rankedDriverIds.Count != expectedCount)
         {
-            throw new ArgumentException($"Must rank all {expectedCount} active drivers (found {rankedDriverIds.Count})");
+            var errorMsg = $"Must rank all {expectedCount} active drivers (you provided {rankedDriverIds.Count}). Expected season: {DateTime.UtcNow.Year}";
+            _logger.LogWarning("[SaveDriverChampionshipAsync] Validation failed: {Error}", errorMsg);
+            throw new ArgumentException(errorMsg);
         }
 
         if (rankedDriverIds.Distinct().Count() != rankedDriverIds.Count)
@@ -125,7 +159,10 @@ public class PredictionService
 
         if (rankedDriverIds.Any(id => !driverIds.Contains(id)))
         {
-            throw new ArgumentException("Invalid driver IDs detected");
+            var invalidIds = rankedDriverIds.Where(id => !driverIds.Contains(id)).ToList();
+            var errorMsg = $"Invalid driver IDs detected: [{string.Join(", ", invalidIds)}]";
+            _logger.LogWarning("[SaveDriverChampionshipAsync] {Error}", errorMsg);
+            throw new ArgumentException(errorMsg);
         }
 
         var prediction = new DriverChampionshipPrediction


### PR DESCRIPTION
- Add detailed logging to GroupsController.GetMyGroups to track 16s performance issue
  * Track timing at controller, service, repository, and enrichment layers
  * Log ClerkService API call timing separately
  * Add stopwatch tracking with millisecond precision

- Add ILogger to GroupService and GroupRepository with detailed timing logs
  * Track group query execution time
  * Log member count and result metrics

- Enhance PredictionService validation with detailed logging
  * Log active driver/constructor counts and IDs
  * Improved error messages include season year and detailed mismatch info
  * Show which specific IDs are invalid when validation fails

- Improve GetActiveDriversAsync and GetActiveConstructorsAsync logging
  * Log initial database query results
  * Track auto-population attempts from external API
  * Warn when no data found and log fetch results
  * Error logging if still empty after API fetch (indicates missing season data)

These changes enable debugging of:
1. Slow GetMyGroups endpoint (likely ClerkService bottleneck)
2. "Must rank all 0 active drivers/constructors" validation errors
3. Auto-population behavior when season data is missing