### PR TITLE
Add predictions to group member DTOs for single-endpoint data fetching

### DIFF
--- a/backend/API_TESTING_GUIDE.md
+++ b/backend/API_TESTING_GUIDE.md
@@ -92,7 +92,60 @@ GET /api/groups/1
 Authorization: Bearer YOUR_TOKEN
 ```
 
-Response: Group details with all members and their display names from Clerk
+Response: Group details with all members, their display names from Clerk, **and all their predictions**
+
+```json
+{
+  "id": 1,
+  "name": "My F1 Fantasy League",
+  "inviteCode": "ABC12XYZ",
+  "lockMode": "admin",
+  "adminUserId": "user_xxx",
+  "predictionsLocked": false,
+  "lockedAt": null,
+  "createdAt": "2025-02-22T14:00:00Z",
+  "members": [
+    {
+      "id": 1,
+      "groupId": 1,
+      "userId": "user_xxx",
+      "displayName": "John Doe",
+      "isAdmin": true,
+      "joinedAt": "2025-02-22T14:00:00Z",
+      "driverChampionship": {
+        "id": 1,
+        "groupId": 1,
+        "userId": "user_xxx",
+        "rankedDriverIds": ["max_verstappen", "charles_leclerc", ...],
+        "createdAt": "2025-02-22T10:00:00Z"
+      },
+      "constructorChampionship": { ... },
+      "driverDraft": { ... },
+      "destructor": { ... },
+      "mrSaturday": { ... },
+      "zeroPointer": { ... },
+      "wildcard": { ... }
+    },
+    {
+      "id": 2,
+      "groupId": 1,
+      "userId": "user_yyy",
+      "displayName": "Jane Smith",
+      "isAdmin": false,
+      "joinedAt": "2025-02-22T15:30:00Z",
+      "driverChampionship": null,
+      "constructorChampionship": null,
+      "driverDraft": { ... },
+      "destructor": null,
+      "mrSaturday": null,
+      "zeroPointer": null,
+      "wildcard": { ... }
+    }
+  ]
+}
+```
+
+**Note**: Any prediction category that hasn't been submitted will be `null`. Perfect for displaying everyone's predictions in one call!
 
 ### 4. Get Group by Invite Code
 ```http
@@ -100,7 +153,7 @@ GET /api/groups/invite/ABC12XYZ
 Authorization: Bearer YOUR_TOKEN
 ```
 
-Response: Group details with members and display names (useful for preview before joining)
+Response: Group details with members, display names, **and all predictions** (useful for preview before joining)
 
 ### 5. Join a Group
 ```http
@@ -317,7 +370,7 @@ POST /api/groups/1/unlock
 Authorization: Bearer ADMIN_TOKEN
 ```
 
-### 12. Get Standings (Auto-Recalculates)
+### 13. Get Standings (Auto-Recalculates)
 ```http
 GET /api/standings/groups/1?season=2025
 Authorization: Bearer YOUR_TOKEN

--- a/backend/F1Fantasy/Controllers/GroupsController.cs
+++ b/backend/F1Fantasy/Controllers/GroupsController.cs
@@ -17,12 +17,14 @@ public class GroupsController : ControllerBase
 {
     private readonly GroupService _groupService;
     private readonly ClerkService _clerkService;
+    private readonly PredictionService _predictionService;
     private readonly ILogger<GroupsController> _logger;
 
-    public GroupsController(GroupService groupService, ClerkService clerkService, ILogger<GroupsController> logger)
+    public GroupsController(GroupService groupService, ClerkService clerkService, PredictionService predictionService, ILogger<GroupsController> logger)
     {
         _groupService = groupService;
         _clerkService = clerkService;
+        _predictionService = predictionService;
         _logger = logger;
     }
 
@@ -82,7 +84,7 @@ public class GroupsController : ControllerBase
         {
             var group = await _groupService.GetGroupByIdAsync(id);
             if (group == null) return NotFound();
-            var groupDto = await EnrichGroupWithMemberNamesAsync(group);
+            var groupDto = await EnrichGroupWithMemberNamesAndPredictionsAsync(group);
             return Ok(groupDto);
         }
         catch (Exception ex)
@@ -98,7 +100,7 @@ public class GroupsController : ControllerBase
         {
             var group = await _groupService.GetGroupByInviteCodeAsync(inviteCode);
             if (group == null) return NotFound();
-            var groupDto = await EnrichGroupWithMemberNamesAsync(group);
+            var groupDto = await EnrichGroupWithMemberNamesAndPredictionsAsync(group);
             return Ok(groupDto);
         }
         catch (Exception ex)
@@ -285,6 +287,48 @@ public class GroupsController : ControllerBase
                 IsAdmin = m.UserId == group.AdminUserId,
                 JoinedAt = m.JoinedAt
             }).ToList()
+        };
+    }
+
+    private async Task<GroupDto> EnrichGroupWithMemberNamesAndPredictionsAsync(Group group)
+    {
+        var userIds = group.Members.Select(m => m.UserId).ToList();
+        var displayNames = await _clerkService.GetUserDisplayNamesAsync(userIds);
+
+        var members = new List<GroupMemberDto>();
+        
+        foreach (var member in group.Members)
+        {
+            var memberDto = new GroupMemberDto
+            {
+                Id = member.Id,
+                GroupId = member.GroupId,
+                UserId = member.UserId,
+                DisplayName = displayNames.GetValueOrDefault(member.UserId, member.UserId),
+                IsAdmin = member.UserId == group.AdminUserId,
+                JoinedAt = member.JoinedAt,
+                DriverChampionship = await _predictionService.GetDriverChampionshipAsync(group.Id, member.UserId),
+                ConstructorChampionship = await _predictionService.GetConstructorChampionshipAsync(group.Id, member.UserId),
+                DriverDraft = await _predictionService.GetDriverDraftAsync(group.Id, member.UserId),
+                Destructor = await _predictionService.GetDestructorAsync(group.Id, member.UserId),
+                MrSaturday = await _predictionService.GetMrSaturdayAsync(group.Id, member.UserId),
+                ZeroPointer = await _predictionService.GetZeroPointerAsync(group.Id, member.UserId),
+                Wildcard = await _predictionService.GetWildcardAsync(group.Id, member.UserId)
+            };
+            members.Add(memberDto);
+        }
+
+        return new GroupDto
+        {
+            Id = group.Id,
+            Name = group.Name,
+            InviteCode = group.InviteCode,
+            LockMode = group.LockMode,
+            AdminUserId = group.AdminUserId,
+            CreatedAt = group.CreatedAt,
+            PredictionsLocked = group.PredictionsLocked,
+            LockedAt = group.LockedAt,
+            Members = members
         };
     }
 

--- a/backend/F1Fantasy/Models/GroupDto.cs
+++ b/backend/F1Fantasy/Models/GroupDto.cs
@@ -21,4 +21,11 @@ public class GroupMemberDto
     public required string DisplayName { get; set; } // Name from Clerk (fallback to username)
     public bool IsAdmin { get; set; }
     public DateTime JoinedAt { get; set; }
+    public DriverChampionshipPrediction? DriverChampionship { get; set; }
+    public ConstructorChampionshipPrediction? ConstructorChampionship { get; set; }
+    public DriverDraftPrediction? DriverDraft { get; set; }
+    public DestructorPrediction? Destructor { get; set; }
+    public MrSaturdayPrediction? MrSaturday { get; set; }
+    public ZeroPointerPrediction? ZeroPointer { get; set; }
+    public WildcardPrediction? Wildcard { get; set; }
 }

--- a/backend/F1Fantasy/Models/MemberPredictionsDto.cs
+++ b/backend/F1Fantasy/Models/MemberPredictionsDto.cs
@@ -1,0 +1,15 @@
+namespace F1Fantasy.Models;
+
+public class MemberPredictionsDto
+{
+    public string UserId { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public bool IsAdmin { get; set; }
+    public DriverChampionshipPrediction? DriverChampionship { get; set; }
+    public ConstructorChampionshipPrediction? ConstructorChampionship { get; set; }
+    public DriverDraftPrediction? DriverDraft { get; set; }
+    public DestructorPrediction? Destructor { get; set; }
+    public MrSaturdayPrediction? MrSaturday { get; set; }
+    public ZeroPointerPrediction? ZeroPointer { get; set; }
+    public WildcardPrediction? Wildcard { get; set; }
+}

--- a/backend/F1Fantasy/Services/PredictionService.cs
+++ b/backend/F1Fantasy/Services/PredictionService.cs
@@ -376,4 +376,39 @@ public class PredictionService
 
         return await _predictionRepository.GetAllWildcardsAsync(groupId);
     }
+
+    public async Task<List<MemberPredictionsDto>> GetAllPredictionsInGroupAsync(int groupId, string userId)
+    {
+        // Verify user is a member of the group
+        if (!await _groupRepository.IsUserMemberAsync(groupId, userId))
+        {
+            throw new UnauthorizedAccessException("User is not a member of this group");
+        }
+
+        // Get all members of the group
+        var members = await _groupRepository.GetMembersAsync(groupId);
+        
+        var result = new List<MemberPredictionsDto>();
+
+        foreach (var member in members)
+        {
+            var memberPredictions = new MemberPredictionsDto
+            {
+                UserId = member.UserId,
+                DisplayName = member.DisplayName,
+                IsAdmin = member.IsAdmin,
+                DriverChampionship = await _predictionRepository.GetDriverChampionshipAsync(groupId, member.UserId),
+                ConstructorChampionship = await _predictionRepository.GetConstructorChampionshipAsync(groupId, member.UserId),
+                DriverDraft = await _predictionRepository.GetDriverDraftAsync(groupId, member.UserId),
+                Destructor = await _predictionRepository.GetDestructorAsync(groupId, member.UserId),
+                MrSaturday = await _predictionRepository.GetMrSaturdayAsync(groupId, member.UserId),
+                ZeroPointer = await _predictionRepository.GetZeroPointerAsync(groupId, member.UserId),
+                Wildcard = await _predictionRepository.GetWildcardAsync(groupId, member.UserId)
+            };
+
+            result.Add(memberPredictions);
+        }
+
+        return result;
+    }
 }


### PR DESCRIPTION
- Enhanced GroupMemberDto to include all prediction categories
- Updated GET /api/groups/{id} and /api/groups/invite/{code} to return member predictions
- Removed standalone /api/predictions/groups/{id}/all endpoint (no longer needed)
- Added EnrichGroupWithMemberNamesAndPredictionsAsync method to GroupsController
- Updated API_TESTING_GUIDE.md to reflect new response structure
- Allows frontend to get all group data + predictions in one API call